### PR TITLE
Release v26.05.6: idempotent release workflow + version bump

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags: ['v*']
 
+# A duplicate workflow trigger for the same tag (GitHub occasionally fires
+# twice in quick succession on a tag push) used to race two `release` jobs
+# against each other and the second would fail with "release already exists".
+# Coalesce to one run per tag.
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 # Least-privilege default for every job. The `release` job overrides this
 # locally with `contents: write` so it can publish the GitHub Release.
 permissions:
@@ -209,7 +217,7 @@ jobs:
       - name: List artifacts
         run: find . -type f -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" | sort
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
@@ -226,8 +234,19 @@ jobs:
           ; do
             [ -f "$f" ] && ASSETS="$ASSETS $f"
           done
-          gh release create "$TAG_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG_NAME" \
-            --generate-notes \
-            $ASSETS
+          # Idempotent: if a previous workflow run already published this tag
+          # (e.g. duplicate trigger, manual re-run, or the concurrency block
+          # above let a second run through), update the existing release in
+          # place instead of failing with "release already exists".
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME exists; uploading assets with --clobber"
+            gh release upload "$TAG_NAME" $ASSETS \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          else
+            gh release create "$TAG_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG_NAME" \
+              --generate-notes \
+              $ASSETS
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v26.05.6 — 2026-05-12
+
+### Build / CI
+
+- **Release workflow is now idempotent on duplicate tag triggers.** GitHub occasionally fires the release workflow twice for the same tag push (it happened on v26.05.5 — runs `25723159486` succeeded, `25723160099` failed with "release already exists"). Two changes prevent the race:
+  - A `concurrency: release-${{ github.ref_name }}` block coalesces simultaneous tag-push triggers into a single workflow run.
+  - The release step now checks for an existing release first and uploads assets with `--clobber` instead of failing if one exists. Either path produces a green status check.
+- No app code changes — this release rebuilds the same set of binaries with the working release pipeline so future releases come up green from the start.
+
 ## v26.05.5 — 2026-05-12
 
 ### New radios

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Download from [GitHub Releases](https://github.com/FlintWave/flintwave-kdh-flash
 
 | OS | Download | Install |
 |----|----------|---------|
-| Linux (Debian/Ubuntu/Pop!_OS/Mint) | [flintwave-flash_amd64.deb](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/flintwave-flash_26.05.5_amd64.deb) | `sudo dpkg -i *.deb` |
-| Linux (Fedora/RHEL/openSUSE) | [flintwave-flash.x86_64.rpm](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/flintwave-flash-v26.05.5-1.x86_64.rpm) | `sudo rpm -i *.rpm` |
+| Linux (Debian/Ubuntu/Pop!_OS/Mint) | [flintwave-flash_amd64.deb](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/flintwave-flash_26.05.6_amd64.deb) | `sudo dpkg -i *.deb` |
+| Linux (Fedora/RHEL/openSUSE) | [flintwave-flash.x86_64.rpm](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/flintwave-flash-v26.05.6-1.x86_64.rpm) | `sudo rpm -i *.rpm` |
 | Windows | [FlintWave-Flash-Setup.exe](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/FlintWave-Flash-Setup.exe) | Run the installer |
 | macOS | [FlintWave-Flash.dmg](https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest/download/FlintWave-Flash.dmg) | Drag to Applications |
 

--- a/flash_firmware_gui.py
+++ b/flash_firmware_gui.py
@@ -16,7 +16,7 @@ from gui_main import main, FlasherFrame  # noqa: F401
 # Canonical version — kept here so tests and build tooling can find it
 # by reading this file.  gui_main.py and gui_dialogs.py import their own
 # copy; keep them in sync when bumping.
-VERSION = "26.05.5"
+VERSION = "26.05.6"
 
 # Single theme: "frappe" — defined in gui_themes.FRAPPE_PALETTE.
 

--- a/gui_dialogs.py
+++ b/gui_dialogs.py
@@ -27,7 +27,7 @@ def _apply_direction(window):
 
 def show_about_dialog(frame):
     """Show the About dialog with version, links, and license."""
-    VERSION = "26.05.5"
+    VERSION = "26.05.6"
 
     dlg = wx.Dialog(frame, title=t("dialog.about.title"), size=(420, 440),
                     style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)

--- a/gui_main.py
+++ b/gui_main.py
@@ -29,7 +29,7 @@ from gui_dialogs import (
 )
 from gui_themes import apply_theme, THEME_PALETTES, MOCHA_PALETTE
 
-VERSION = "26.05.5"
+VERSION = "26.05.6"
 
 FONT_SIZES = [9, 11, 12, 14, 16]
 


### PR DESCRIPTION
## Summary

GitHub fired the release workflow twice for the v26.05.5 tag push — run [25723159486](https://github.com/FlintWave/flintwave-kdh-flasher/actions/runs/25723159486) succeeded and published the release; run [25723160099](https://github.com/FlintWave/flintwave-kdh-flasher/actions/runs/25723160099) then failed with \`release with the same tag name already exists\`. Functionally the binaries shipped, but the failed status check is noise we can avoid.

Two layered fixes in \`.github/workflows/build-release.yml\`:

1. **\`concurrency: release-\${{ github.ref_name }}\`** — coalesces simultaneous tag-push triggers into a single workflow run before they race.
2. **Idempotent release step** — checks \`gh release view\` first; if the release already exists, uses \`gh release upload --clobber\` to refresh assets instead of failing.

No app code changes — same binary set rebuilt under the working pipeline so v26.05.6 (and every future release) comes up green.

## Test plan

- [x] \`python3 tests.py\` — 112/112 passing
- [x] YAML lints / parses (verified by GitHub on push)
- [ ] Tag pushes \`v26.05.6\` and shows a green \`release\` job in CI
- [ ] If GitHub somehow fires the workflow twice anyway, the second run no-ops cleanly via \`--clobber\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)