### PR TITLE
Update RT-470 firmware to v2.13C, add RT-490 New PCB entry

### DIFF
--- a/firmware_manifest.json
+++ b/firmware_manifest.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Remote firmware manifest. Update this file to publish new firmware URLs without requiring an app update. Community contributions welcome — submit a PR.",
-  "_updated": "2026-04-01",
+  "_updated": "2026-07-02",
   "manifest_version": 1,
   "radios": {
     "bf-f8hp-pro": {
@@ -16,10 +16,10 @@
       "release_notes": "V0.20: fixed GPS radar distance display after location sharing"
     },
     "rt-470": {
-      "firmware_version": "2.12A",
-      "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_2.12A.rar",
+      "firmware_version": "2.13C",
+      "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_RT470X_RT470L_NEW_PCB_8.33KHZ_V2.13C_20240425.rar",
       "firmware_sha256": null,
-      "release_notes": "V2.12A: new PCB, full band"
+      "release_notes": "V2.13C: AM/FM modulation switch 18MHz-1000MHz, 8.33kHz air band (470X/470/470L, new PCB)"
     },
     "rt-490": {
       "firmware_version": "1.03",

--- a/firmware_manifest.json
+++ b/firmware_manifest.json
@@ -26,6 +26,12 @@
       "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/Firmware_Version_1.03.zip",
       "firmware_sha256": null,
       "release_notes": "V1.03: old PCB firmware"
+    },
+    "rt-490-new": {
+      "firmware_version": "1.25a",
+      "firmware_url": null,
+      "firmware_sha256": null,
+      "release_notes": "V1.25a: new PCB, channel name editing"
     }
   }
 }

--- a/radios.json
+++ b/radios.json
@@ -51,7 +51,20 @@
       "bootloader_keys": "Unknown — check manual",
       "connector": "K1 Kenwood 2-pin",
       "tested": false,
-      "notes": "Shares JJCC JC-8629 PCB. KDH bootloader. This URL is for the old PCB (v1.03). Newer PCB versions with channel name editing available on radtels.com."
+      "notes": "Shares JJCC JC-8629 PCB. KDH bootloader. This URL is for the OLD PCB (v1.03). If your RT-490 has channel name editing, you have the new PCB — select 'Radtel RT-490 (New PCB)' instead."
+    },
+    {
+      "id": "rt-490-new",
+      "name": "Radtel RT-490 (New PCB)",
+      "manufacturer": "Radtel",
+      "model_type": "WLT",
+      "firmware_url": null,
+      "firmware_page": "https://www.radtels.com/pages/software-download",
+      "firmware_filename_pattern": "*.kdhx",
+      "bootloader_keys": "Unknown — check manual",
+      "connector": "K1 Kenwood 2-pin",
+      "tested": false,
+      "notes": "Radtel RT-490 with NEW PCB (supports channel name editing). Only use firmware v1.23a/v1.24a/v1.25a — do NOT use V2.11A or old-PCB firmware, it will brick the radio. Same JJCC JC-8629 platform. Download firmware from radtels.com or browse for a .kdhx file."
     },
     {
       "id": "socotran-jc8629",

--- a/radios.json
+++ b/radios.json
@@ -32,13 +32,13 @@
       "name": "Radtel RT-470",
       "manufacturer": "Radtel",
       "model_type": "WLT",
-      "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_2.12A.rar",
+      "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_RT470X_RT470L_NEW_PCB_8.33KHZ_V2.13C_20240425.rar",
       "firmware_page": "https://www.radtels.com/pages/software-download",
       "firmware_filename_pattern": "*.kdhx",
       "bootloader_keys": "Unknown — check manual",
       "connector": "K1 Kenwood 2-pin",
       "tested": false,
-      "notes": "Uses WLT2000 CPS. KDH bootloader with .kdhx firmware. This URL is for the NEW PCB (V2.12A, full band). Old PCB (10W) uses different firmware — see radtels.com."
+      "notes": "Uses WLT2000 CPS. KDH bootloader with .kdhx firmware. This URL is for the NEW PCB (V2.13C, AM/FM modulation 18MHz-1000MHz, 8.33kHz air band). Old PCB (10W) uses different firmware — see radtels.com."
     },
     {
       "id": "rt-490",


### PR DESCRIPTION
## Summary

- Update Radtel RT-470 firmware from v2.12A to v2.13C in both `firmware_manifest.json` and `radios.json` — adds AM/FM modulation switching 18MHz-1000MHz and 8.33kHz air band spacing (470X/470/470L, new PCB)
- Add separate `rt-490-new` entry for the Radtel RT-490 New PCB (v1.25a) — the old and new PCB revisions use incompatible firmware, so they need distinct entries to prevent bricking
- Update old RT-490 entry notes to direct new-PCB users to the correct entry
- BTECH BF-F8HP Pro (v0.53) and Baofeng UV-25 Plus (v0.20) are already at their latest versions

**Note:** The RT-490 New PCB `firmware_url` is `null` pending the CDN download link — users can still browse for a local `.kdhx` file. The URL will be added in a follow-up once confirmed.

## Test plan

- [ ] Verify the new RT-470 firmware URL resolves (Shopify CDN link)
- [ ] Confirm `firmware_version.py` parses `2.13C` and `1.25a` correctly
- [ ] Launch the app — confirm RT-470 offers v2.13C, and "Radtel RT-490 (New PCB)" appears as a separate radio in the dropdown
- [ ] Confirm old RT-490 entry still works and points to v1.03
- [ ] Verify other radios (BF-F8HP Pro, UV-25 Plus) are unaffected
- [ ] Once CDN URL is provided, update `firmware_url` for `rt-490-new` and verify auto-download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dutb8rbEir251M9UPcxKuN