### PR TITLE
Mock bootloader + end-to-end flash tests

### DIFF
--- a/mock_bootloader.py
+++ b/mock_bootloader.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""
+In-memory mock bootloaders for end-to-end flash testing without hardware.
+
+The real flashers (:mod:`flash_firmware` for the KDH protocol, :mod:`flash_btf`
+for the .BTF / BOOTLOADER_V3 protocol) open a ``serial.Serial`` port and drive a
+full handshake → announce → stream → finalize sequence over the wire. Until now
+the test suite only exercised packet *framing* in isolation; the actual
+send/receive state machine — chunk counting, sequence numbers, retry-on-error,
+ordering enforcement — was only ever validated against a physical radio.
+
+This module provides a fake serial endpoint that speaks each protocol back to
+the flasher, so the whole sequence can be driven in a unit test:
+
+    engine = KDHBootloader()
+    with patch_serial(flash_firmware, engine=engine):
+        flash_firmware.flash_to_port("/dev/mock", firmware)
+    assert engine.finished
+    assert engine.reassembled_firmware() == expected_padded_bytes
+
+The engines are deliberately strict state machines: they answer 0xE5
+("command error") when the flasher sends a command out of order, so a flasher
+regression that streamed data before announcing the chunk count would be caught
+here rather than on someone's radio. They also support fault injection
+(``chunk_nak_once``, ``chunk_fatal``, ``bad_handshake``, ``model_mismatch``) so
+the retryable/fatal error branches can be exercised deterministically.
+
+Nothing here imports :mod:`serial` — the fake module shim supplies the handful
+of attributes the flashers touch (``Serial``, ``PARITY_NONE``, ``STOPBITS_ONE``,
+``SerialException``), so these tests run on any machine, in CI, with no pyserial
+and no hardware.
+"""
+
+import contextlib
+
+import flash_firmware as _kdh
+import flash_btf as _btf
+from flash_firmware import crc16_ccitt
+
+ACK = 0x06
+
+
+# --------------------------------------------------------------------------- #
+# Fake serial transport
+# --------------------------------------------------------------------------- #
+class MockSerial:
+    """A minimal drop-in for ``serial.Serial`` backed by a bootloader engine.
+
+    Bytes written by the flasher are fed to ``engine`` as soon as a complete
+    packet is buffered; the engine's framed response is queued for the flasher
+    to read back. Everything is synchronous — by the time ``write()`` returns,
+    the response is already sitting in the read buffer — so no threads or real
+    timing are involved.
+    """
+
+    def __init__(self, engine, port=None, **kwargs):
+        self.engine = engine
+        self.port = port
+        self._rx = bytearray()   # bytes waiting for the flasher to read()
+        self._tx = bytearray()   # partial inbound packet from the flasher
+        self.is_open = True
+        # Modem-control lines the flashers set; stored so assignment works.
+        self.dtr = False
+        self.rts = False
+        self.name = port
+
+    # -- context manager -------------------------------------------------- #
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def close(self):
+        self.is_open = False
+
+    # -- buffer management ------------------------------------------------ #
+    @property
+    def in_waiting(self):
+        return len(self._rx)
+
+    def reset_input_buffer(self):
+        self._rx.clear()
+
+    def reset_output_buffer(self):
+        self._tx.clear()
+
+    def flush(self):
+        pass
+
+    # -- I/O -------------------------------------------------------------- #
+    def write(self, data):
+        self._tx.extend(data)
+        self._pump()
+        return len(data)
+
+    def read(self, n=1):
+        out = bytes(self._rx[:n])
+        del self._rx[:n]
+        return out
+
+    def _pump(self):
+        """Extract whole packets from the tx buffer and queue engine replies."""
+        while self._tx:
+            kind, size = self.engine.try_extract(self._tx)
+            if kind is None:
+                break                       # need more bytes
+            if kind == "drop":
+                del self._tx[:size]         # resync past a stray byte
+                continue
+            packet = bytes(self._tx[:size])
+            del self._tx[:size]
+            resp = self.engine.handle(packet)
+            if resp:
+                self._rx.extend(resp)
+
+
+class _FakeSerialModule:
+    """Stand-in for the ``serial`` module the flashers import.
+
+    A ``registry`` maps port name → engine (for batch/multi-port flows); a bare
+    ``engine`` is used for any port not in the registry.
+    """
+
+    PARITY_NONE = "N"
+    STOPBITS_ONE = 1
+    EIGHTBITS = 8
+
+    class SerialException(Exception):
+        pass
+
+    def __init__(self, engine=None, registry=None):
+        self.engine = engine
+        self.registry = dict(registry or {})
+        self.opened = []               # (port, MockSerial) for assertions
+
+    def Serial(self, port=None, **kwargs):
+        eng = self.registry.get(port, self.engine)
+        if eng is None:
+            raise self.SerialException(f"no mock bootloader registered for {port!r}")
+        ser = MockSerial(eng, port=port, **kwargs)
+        self.opened.append((port, ser))
+        return ser
+
+
+@contextlib.contextmanager
+def patch_serial(*modules, engine=None, registry=None):
+    """Temporarily point ``module.serial`` at a fake backed by mock engines.
+
+    Usage::
+
+        with patch_serial(flash_firmware, engine=my_engine):
+            flash_firmware.flash_to_port(...)
+
+    Restores the original ``serial`` attribute (often ``None`` in a
+    pyserial-free environment) on exit.
+    """
+    fake = _FakeSerialModule(engine=engine, registry=registry)
+    saved = [(m, getattr(m, "serial", None)) for m in modules]
+    try:
+        for m in modules:
+            m.serial = fake
+        yield fake
+    finally:
+        for m, old in saved:
+            m.serial = old
+
+
+# --------------------------------------------------------------------------- #
+# KDH bootloader (flash_firmware protocol)
+# --------------------------------------------------------------------------- #
+class KDHBootloader:
+    """Simulates a radio in KDH bootloader mode.
+
+    State machine: idle → handshaked → counted → done. Each response is a real
+    framed packet whose ``args`` byte is ACK (0x06) on success or an error code
+    (0xE1..0xE5) on failure, matching what ``flash_firmware.send_command``
+    inspects.
+
+    Fault injection:
+      * ``bad_handshake``     — answer 0xE1 to CMD_HANDSHAKE.
+      * ``chunk_nak_once``    — iterable of seq numbers that NAK (0xE2,
+                                retryable) on their first attempt then ACK.
+      * ``chunk_fatal``       — ``(seq, code)`` returning a fatal error (0xE4)
+                                for that chunk on every attempt.
+    """
+
+    HEADER = 0xAA
+    TRAILER = 0xEF
+
+    def __init__(self, *, bad_handshake=False, chunk_nak_once=None,
+                 chunk_fatal=None):
+        self.bad_handshake = bad_handshake
+        self.chunk_nak_once = set(chunk_nak_once or ())
+        self.chunk_fatal = chunk_fatal
+        self.state = "idle"
+        self.expected_chunks = None
+        self.received_chunks = []      # payloads ACK'd, in order
+        self.transcript = []           # (cmd, seed, data_len) per received pkt
+        self.finished = False
+        self._naked = set()
+
+    # -- framing ---------------------------------------------------------- #
+    def try_extract(self, buf):
+        if not buf:
+            return None, 0
+        if buf[0] != self.HEADER:
+            return "drop", 1
+        if len(buf) < 5:
+            return None, 0
+        data_len = (buf[3] << 8) | buf[4]
+        total = data_len + 8           # 0xAA + 4 hdr + data + crc(2) + trailer
+        if len(buf) < total:
+            return None, 0
+        return "packet", total
+
+    def _resp(self, cmd, status):
+        # args byte carries ACK or the error code; flash_firmware reads buf[2].
+        return _kdh.build_packet(cmd, status)
+
+    def handle(self, packet):
+        cmd = packet[1]
+        seed = packet[2]
+        data_len = (packet[3] << 8) | packet[4]
+        data = packet[5:5 + data_len]
+        self.transcript.append((cmd, seed, data_len))
+
+        # Integrity check — a corrupt frame is a retryable verification error.
+        crc_recv = (packet[5 + data_len] << 8) | packet[6 + data_len]
+        crc_calc = crc16_ccitt(packet[1:5 + data_len])
+        if packet[-1] != self.TRAILER or crc_recv != crc_calc:
+            return self._resp(cmd, 0xE2)
+
+        if cmd == _kdh.CMD_HANDSHAKE:
+            if self.bad_handshake or data != b"BOOTLOADER":
+                return self._resp(cmd, 0xE1)
+            self.state = "handshaked"
+            return self._resp(cmd, ACK)
+
+        if cmd == _kdh.CMD_UPDATE_DATA_PACKAGES:
+            if self.state not in ("handshaked", "counted"):
+                return self._resp(cmd, 0xE5)
+            self.expected_chunks = data[0] if data else 0
+            self.received_chunks = []
+            self.state = "counted"
+            return self._resp(cmd, ACK)
+
+        if cmd == _kdh.CMD_UPDATE:
+            if self.state != "counted":
+                return self._resp(cmd, 0xE5)
+            seq = seed
+            if self.chunk_fatal and seq == self.chunk_fatal[0]:
+                return self._resp(cmd, self.chunk_fatal[1])
+            if seq in self.chunk_nak_once and seq not in self._naked:
+                self._naked.add(seq)
+                return self._resp(cmd, 0xE2)   # retryable; chunk not stored
+            self.received_chunks.append(data)
+            return self._resp(cmd, ACK)
+
+        if cmd == _kdh.CMD_UPDATE_END:
+            if self.state != "counted":
+                return self._resp(cmd, 0xE5)
+            self.state = "done"
+            self.finished = True
+            return self._resp(cmd, ACK)
+
+        return self._resp(cmd, 0xE5)           # unknown command
+
+    # -- assertions helpers ---------------------------------------------- #
+    def reassembled_firmware(self):
+        return b"".join(self.received_chunks)
+
+    def commands_seen(self):
+        return [t[0] for t in self.transcript]
+
+
+# --------------------------------------------------------------------------- #
+# BTF bootloader (flash_btf / BOOTLOADER_V3 protocol)
+# --------------------------------------------------------------------------- #
+class BTFBootloader:
+    """Simulates a radio in .BTF (AT32F403A) bootloader mode.
+
+    State machine: idle → probed → versioned → modeled → counted → done.
+    Responses are the fixed 9-byte form
+    ``[0xAA][cmd][0x00][result][0x00][0x00][crcH][crcL][0x55]`` that
+    ``flash_btf.parse_response`` decodes (result at index 3).
+
+    Fault injection:
+      * ``model_mismatch`` — answer 0xE6 to CMD_MODEL.
+      * ``chunk_nak_once`` — seqs that NAK (0xE2, retryable) once then ACK.
+      * ``chunk_fatal``    — ``(seq, code)`` fatal error for that chunk.
+      * ``end_status``     — override the CMD_END result (default ACK).
+    """
+
+    HEADER = 0xAA
+    TRAILER = 0x55
+
+    def __init__(self, *, model_mismatch=False, chunk_nak_once=None,
+                 chunk_fatal=None, end_status=ACK):
+        self.model_mismatch = model_mismatch
+        self.chunk_nak_once = set(chunk_nak_once or ())
+        self.chunk_fatal = chunk_fatal
+        self.end_status = end_status
+        self.state = "idle"
+        self.expected_chunks = None
+        self.received_chunks = []
+        self.transcript = []           # (cmd, args, data_len)
+        self.model_sig = None
+        self.finished = False
+        self._naked = set()
+
+    def try_extract(self, buf):
+        if not buf:
+            return None, 0
+        if buf[0] != self.HEADER:
+            return "drop", 1
+        if len(buf) < 6:
+            return None, 0
+        data_len = (buf[4] << 8) | buf[5]
+        total = data_len + 9           # 0xAA + 5 hdr + data + crc(2) + trailer
+        if len(buf) < total:
+            return None, 0
+        return "packet", total
+
+    def _resp(self, cmd, result):
+        payload = bytes([cmd, 0x00, result, 0x00, 0x00])
+        crc = crc16_ccitt(payload)
+        return bytes([self.HEADER]) + payload + bytes([(crc >> 8) & 0xFF,
+                                                       crc & 0xFF]) + bytes([self.TRAILER])
+
+    def handle(self, packet):
+        cmd = packet[1]
+        args = (packet[2] << 8) | packet[3]
+        data_len = (packet[4] << 8) | packet[5]
+        data = packet[6:6 + data_len]
+        self.transcript.append((cmd, args, data_len))
+
+        crc_recv = (packet[6 + data_len] << 8) | packet[7 + data_len]
+        crc_calc = crc16_ccitt(packet[1:6 + data_len])
+        if packet[-1] != self.TRAILER or crc_recv != crc_calc:
+            return self._resp(cmd, 0xE2)
+
+        if cmd == _btf.CMD_PROBE:
+            self.state = "probed"
+            return self._resp(cmd, ACK)
+
+        if cmd == _btf.CMD_VERSION:
+            if data != _btf.VERSION_STRING:
+                return self._resp(cmd, 0xE5)
+            self.state = "versioned"
+            return self._resp(cmd, ACK)
+
+        if cmd == _btf.CMD_MODEL:
+            if self.state not in ("versioned", "probed"):
+                return self._resp(cmd, 0xE5)
+            if self.model_mismatch:
+                return self._resp(cmd, 0xE6)
+            self.model_sig = data
+            self.state = "modeled"
+            return self._resp(cmd, ACK)
+
+        if cmd == _btf.CMD_PKG_COUNT:
+            if self.state != "modeled":
+                return self._resp(cmd, 0xE5)
+            self.expected_chunks = ((data[0] << 8) | data[1]) + 1 if len(data) >= 2 else 0
+            self.received_chunks = []
+            self.state = "counted"
+            return self._resp(cmd, ACK)
+
+        if cmd == _btf.CMD_DATA:
+            if self.state != "counted":
+                return self._resp(cmd, 0xE5)
+            seq = args
+            if self.chunk_fatal and seq == self.chunk_fatal[0]:
+                return self._resp(cmd, self.chunk_fatal[1])
+            if seq in self.chunk_nak_once and seq not in self._naked:
+                self._naked.add(seq)
+                return self._resp(cmd, 0xE2)
+            self.received_chunks.append(data)
+            return self._resp(cmd, ACK)
+
+        if cmd == _btf.CMD_END:
+            self.state = "done"
+            self.finished = True
+            return self._resp(cmd, self.end_status)
+
+        return self._resp(cmd, 0xE5)
+
+    def reassembled_firmware(self):
+        return b"".join(self.received_chunks)
+
+    def commands_seen(self):
+        return [t[0] for t in self.transcript]

--- a/mock_bootloader.py
+++ b/mock_bootloader.py
@@ -35,7 +35,8 @@ import contextlib
 
 import flash_firmware as _kdh
 import flash_btf as _btf
-from flash_firmware import crc16_ccitt
+
+crc16_ccitt = _kdh.crc16_ccitt
 
 ACK = 0x06
 

--- a/tests.py
+++ b/tests.py
@@ -1062,5 +1062,216 @@ class TestRadioStringTranslations(unittest.TestCase):
                          f"source (model echo): {echoed[:5]}")
 
 
+class TestEndToEndFlashKDH(unittest.TestCase):
+    """Drive flash_firmware.flash_to_port end-to-end against a mock radio.
+
+    These exercise the full send/receive state machine — handshake, chunk-count
+    announce, per-chunk streaming, retry-on-error, finalize — which the framing
+    tests above never touch. The mock is a strict bootloader: it verifies CRCs,
+    enforces command ordering, and reassembles the bytes it was sent so we can
+    assert the radio received exactly the firmware, padded, in order.
+    """
+
+    def setUp(self):
+        import flash_firmware
+        import mock_bootloader as mb
+        self.flash_firmware = flash_firmware
+        self.mb = mb
+
+    def _firmware(self, size):
+        header = struct.pack("<II", 0x200078E0, 0x08001185)
+        return header + bytes((i * 7) & 0xFF for i in range(size - len(header)))
+
+    def _padded(self, firmware):
+        pad = (-len(firmware)) % 1024
+        return firmware + b"\x00" * pad
+
+    def _flash(self, engine, firmware):
+        logs, prog = [], []
+        with self.mb.patch_serial(self.flash_firmware, engine=engine):
+            self.flash_firmware.flash_to_port(
+                "/dev/mock", firmware,
+                log_cb=logs.append, progress_cb=prog.append)
+        return logs, prog
+
+    def test_full_flash_delivers_exact_bytes(self):
+        firmware = self._firmware(3 * 1024 + 200)   # 4 chunks, last padded
+        engine = self.mb.KDHBootloader()
+        _, prog = self._flash(engine, firmware)
+        self.assertTrue(engine.finished)
+        self.assertEqual(len(engine.received_chunks), 4)
+        self.assertEqual(engine.reassembled_firmware(), self._padded(firmware))
+        self.assertAlmostEqual(prog[-1], 100.0)
+
+    def test_command_sequence_and_order(self):
+        firmware = self._firmware(2 * 1024)
+        engine = self.mb.KDHBootloader()
+        self._flash(engine, firmware)
+        cmds = engine.commands_seen()
+        # Handshake first, then announce, then the data chunks, then end.
+        self.assertEqual(cmds[0], fw.CMD_HANDSHAKE)
+        self.assertEqual(cmds[1], fw.CMD_UPDATE_DATA_PACKAGES)
+        self.assertEqual(cmds[-1], fw.CMD_UPDATE_END)
+        self.assertEqual(cmds.count(fw.CMD_UPDATE), 2)
+
+    def test_announced_chunk_count_matches_data(self):
+        firmware = self._firmware(5 * 1024)
+        engine = self.mb.KDHBootloader()
+        self._flash(engine, firmware)
+        self.assertEqual(engine.expected_chunks, 5)
+        self.assertEqual(len(engine.received_chunks), engine.expected_chunks)
+
+    def test_retryable_error_recovers(self):
+        # Chunk 1 NAKs once (0xE2) then succeeds; the flasher must resend it and
+        # still deliver every byte in order.
+        firmware = self._firmware(3 * 1024)
+        engine = self.mb.KDHBootloader(chunk_nak_once={1})
+        self._flash(engine, firmware)
+        self.assertTrue(engine.finished)
+        self.assertEqual(len(engine.received_chunks), 3)
+        self.assertEqual(engine.reassembled_firmware(), self._padded(firmware))
+
+    def test_fatal_error_aborts(self):
+        firmware = self._firmware(3 * 1024)
+        engine = self.mb.KDHBootloader(chunk_fatal=(1, 0xE4))  # flash write error
+        with self.assertRaises(RuntimeError):
+            self._flash(engine, firmware)
+        self.assertFalse(engine.finished)
+
+    def test_bad_handshake_aborts_before_streaming(self):
+        firmware = self._firmware(2 * 1024)
+        engine = self.mb.KDHBootloader(bad_handshake=True)
+        with self.assertRaises(RuntimeError):
+            self._flash(engine, firmware)
+        self.assertEqual(len(engine.received_chunks), 0)
+
+    def test_probe_port_detects_bootloader(self):
+        engine = self.mb.KDHBootloader()
+        with self.mb.patch_serial(self.flash_firmware, engine=engine):
+            self.assertTrue(self.flash_firmware.probe_port("/dev/mock"))
+
+    def test_out_of_order_command_rejected(self):
+        # Directly poke the state machine: a data chunk before the count
+        # announce must be refused with 0xE5 (command error), so a flasher that
+        # skipped the announce step would fail here instead of on a radio.
+        engine = self.mb.KDHBootloader()
+        engine.state = "handshaked"          # handshaked but no chunk count yet
+        pkt = fw.build_packet(fw.CMD_UPDATE, 0, b"\x00" * 1024)
+        resp = engine.handle(pkt)
+        # response args byte carries the error code
+        self.assertEqual(resp[2], 0xE5)
+
+
+class TestEndToEndFlashBTF(unittest.TestCase):
+    """Drive flash_btf.flash_to_port end-to-end against a mock RT-950 Pro."""
+
+    def setUp(self):
+        import flash_btf
+        import mock_bootloader as mb
+        self.flash_btf = flash_btf
+        self.mb = mb
+
+    def _btf(self, data_chunks):
+        size = self.flash_btf.BTF_KEY_OFFSET + self.flash_btf.BTF_KEY_SIZE \
+            + data_chunks * 1024
+        blob = bytearray(struct.pack("<II", 0x20001000, 0x08003185))
+        blob += bytes((i * 3) & 0xFF for i in range(size - 8))
+        sig = b"RT950PRO\x00"
+        blob[self.flash_btf.BTF_MODEL_OFFSET:
+             self.flash_btf.BTF_MODEL_OFFSET + len(sig)] = sig
+        return bytes(blob)
+
+    def _padded(self, blob):
+        pad = (-len(blob)) % 1024
+        return blob + b"\x00" * pad
+
+    def _flash(self, engine, blob):
+        import contextlib
+        import io
+        logs = []
+        with contextlib.redirect_stdout(io.StringIO()):
+            with self.mb.patch_serial(self.flash_btf, engine=engine):
+                self.flash_btf.flash_to_port(
+                    "/dev/mock", blob, log_cb=logs.append)
+        return logs
+
+    def test_full_btf_flash_delivers_exact_bytes(self):
+        blob = self._btf(3)
+        engine = self.mb.BTFBootloader()
+        self._flash(engine, blob)
+        self.assertTrue(engine.finished)
+        self.assertEqual(engine.reassembled_firmware(), self._padded(blob))
+
+    def test_btf_command_sequence(self):
+        blob = self._btf(2)
+        engine = self.mb.BTFBootloader()
+        self._flash(engine, blob)
+        import flash_btf as b
+        cmds = engine.commands_seen()
+        self.assertEqual(cmds[0], b.CMD_PROBE)
+        self.assertIn(b.CMD_VERSION, cmds)
+        self.assertIn(b.CMD_MODEL, cmds)
+        self.assertIn(b.CMD_PKG_COUNT, cmds)
+        self.assertEqual(cmds[-1], b.CMD_END)
+
+    def test_btf_pkg_count_is_chunks_minus_one(self):
+        blob = self._btf(4)
+        total = math.ceil(len(blob) / 1024)
+        engine = self.mb.BTFBootloader()
+        self._flash(engine, blob)
+        # flash_btf announces (total_chunks - 1); the radio decodes it back to
+        # the full count and receives exactly that many chunks.
+        self.assertEqual(engine.expected_chunks, total)
+        self.assertEqual(len(engine.received_chunks), total)
+
+    def test_btf_retryable_error_recovers(self):
+        blob = self._btf(3)
+        engine = self.mb.BTFBootloader(chunk_nak_once={1})
+        self._flash(engine, blob)
+        self.assertTrue(engine.finished)
+        self.assertEqual(engine.reassembled_firmware(), self._padded(blob))
+
+    def test_btf_model_mismatch_aborts(self):
+        blob = self._btf(2)
+        engine = self.mb.BTFBootloader(model_mismatch=True)
+        with self.assertRaises(RuntimeError):
+            self._flash(engine, blob)
+        self.assertEqual(len(engine.received_chunks), 0)
+
+    def test_btf_probe_port_detects_bootloader(self):
+        engine = self.mb.BTFBootloader()
+        with self.mb.patch_serial(self.flash_btf, engine=engine):
+            self.assertTrue(self.flash_btf.probe_port("/dev/mock"))
+
+    def test_btf_end_nonack_is_tolerated(self):
+        # The radio may reset mid-END and reply with a non-ACK status; the
+        # flasher treats that as still-successful (logs, does not raise).
+        blob = self._btf(2)
+        engine = self.mb.BTFBootloader(end_status=0xE5)
+        logs = self._flash(engine, blob)
+        self.assertTrue(engine.finished)
+        self.assertTrue(any("complete" in m.lower() for m in logs))
+
+
+class TestBatchFlashRouting(unittest.TestCase):
+    """Multiple ports route to independent mock radios (batch-flash shape)."""
+
+    def test_two_ports_flash_independently(self):
+        import flash_firmware
+        import mock_bootloader as mb
+        firmware = struct.pack("<II", 0x200078E0, 0x08001185) + b"\x5A" * (2 * 1024 - 8)
+        eng_a = mb.KDHBootloader()
+        eng_b = mb.KDHBootloader()
+        registry = {"/dev/ttyUSB0": eng_a, "/dev/ttyUSB1": eng_b}
+        with mb.patch_serial(flash_firmware, registry=registry):
+            for port in registry:
+                flash_firmware.flash_to_port(port, firmware)
+        self.assertTrue(eng_a.finished)
+        self.assertTrue(eng_b.finished)
+        pad = firmware + b"\x00" * ((-len(firmware)) % 1024)
+        self.assertEqual(eng_a.reassembled_firmware(), pad)
+        self.assertEqual(eng_b.reassembled_firmware(), pad)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests.py
+++ b/tests.py
@@ -1073,9 +1073,8 @@ class TestEndToEndFlashKDH(unittest.TestCase):
     """
 
     def setUp(self):
-        import flash_firmware
         import mock_bootloader as mb
-        self.flash_firmware = flash_firmware
+        self.flash_firmware = fw
         self.mb = mb
 
     def _firmware(self, size):
@@ -1257,15 +1256,14 @@ class TestBatchFlashRouting(unittest.TestCase):
     """Multiple ports route to independent mock radios (batch-flash shape)."""
 
     def test_two_ports_flash_independently(self):
-        import flash_firmware
         import mock_bootloader as mb
         firmware = struct.pack("<II", 0x200078E0, 0x08001185) + b"\x5A" * (2 * 1024 - 8)
         eng_a = mb.KDHBootloader()
         eng_b = mb.KDHBootloader()
         registry = {"/dev/ttyUSB0": eng_a, "/dev/ttyUSB1": eng_b}
-        with mb.patch_serial(flash_firmware, registry=registry):
+        with mb.patch_serial(fw, registry=registry):
             for port in registry:
-                flash_firmware.flash_to_port(port, firmware)
+                fw.flash_to_port(port, firmware)
         self.assertTrue(eng_a.finished)
         self.assertTrue(eng_b.finished)
         pad = firmware + b"\x00" * ((-len(firmware)) % 1024)


### PR DESCRIPTION
## Summary

Closes the "untested on hardware" gap by adding a **mock bootloader** that lets the full flash sequence be driven in a unit test — no radio, no serial cable, no pyserial required.

Until now the suite only validated packet *framing* in isolation. The actual send/receive state machine (handshake → announce chunk count → stream chunks → finalize, plus retry-on-error) was only ever exercised against a physical radio. That's the risk surface most likely to brick a device on a regression.

## What's new

**`mock_bootloader.py`** — in-memory fake `serial.Serial` endpoints that speak each protocol back to the real flashers:

- `KDHBootloader` — simulates a radio in KDH bootloader mode (`flash_firmware` path).
- `BTFBootloader` — simulates an RT-950 Pro in .BTF / `BOOTLOADER_V3` mode (`flash_btf` path).
- `patch_serial(...)` — context manager that points `module.serial` at the fake for the duration of a test and restores it after.

Each engine is a **strict** state machine: it verifies incoming CRCs, enforces command ordering (answers `0xE5` to an out-of-order command), and reassembles the bytes it was sent so a test can assert the radio received *exactly* the firmware, padded, in order. Fault injection covers retryable NAKs (`0xE2`), fatal errors (`0xE4`), bad handshakes (`0xE1`), and BTF model mismatch (`0xE6`).

The fake supplies its own `serial`-module shim, so the tests run anywhere — including CI — with no pyserial installed and no hardware attached.

**16 new end-to-end tests (112 → 128)** driving `flash_to_port` / `probe_port` for both protocols:

- Byte-exact firmware delivery (reassembled chunks == padded firmware)
- Command sequence and ordering
- Announced chunk count matches data streamed
- Retry-then-recover on a retryable NAK
- Abort on fatal error / bad handshake / model mismatch
- BTF `CMD_END` non-ACK tolerated (radio resets mid-finalize)
- Multi-port batch routing (independent mock radios per port)

## Testing

`python3 tests.py` → **128 passed** (8 skipped: GUI/theme tests that need wxPython, unchanged from before).

## Notes / follow-ups

This unlocks the next two items from the project-direction discussion: a CI workflow that runs `tests.py` on every push/PR (these tests need no hardware, so they're CI-ready today), and it gives regression coverage before any `gui_main.py` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_