### PR TITLE
Add CI workflow running the test suite on push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Only the latest push per branch/PR needs to run; cancel superseded runs.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the system Python (3.12 on ubuntu-latest) together with the
+      # apt-packaged dependencies — this mirrors the project's documented
+      # Linux install path (README) and avoids the setup-python / apt-wxPython
+      # interpreter mismatch. With wxPython, pyserial, and requests all present
+      # the GUI/theme/i18n tests actually run instead of self-skipping.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3-wxgtk4.0 \
+            python3-serial \
+            python3-requests \
+            xvfb
+
+      - name: Show environment
+        run: |
+          python3 --version
+          python3 -c "import wx, serial, requests; print('wx', wx.__version__)"
+
+      # gui_themes / gui_main import wx.adv, so a display must exist even to
+      # import them; xvfb-run supplies a headless one.
+      - name: Run test suite
+        run: xvfb-run -a python3 tests.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlintWave Flash
 
+[![Tests](https://github.com/FlintWave/flintwave-kdh-flasher/actions/workflows/tests.yml/badge.svg)](https://github.com/FlintWave/flintwave-kdh-flasher/actions/workflows/tests.yml)
+
 A cross-platform tool for flashing `.kdhx` firmware to radios that use the KDH bootloader — BTECH, Baofeng, Radtel, and others. Works on Linux, macOS, and Windows.
 
 Maintained by [FlintWave Radio Tools](https://github.com/FlintWave). Contact: flintwave@tuta.com


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow so `tests.py` runs automatically on every push to `master` and every PR. Until now nothing ran the suite in CI — it only executed when someone remembered to run it locally, and its GUI/theme/i18n tests silently self-skipped whenever wxPython/requests weren't importable.

This is the second item from the project-direction discussion, and it's what turns the hardware-free end-to-end flash tests (merged in #13) into a real merge gate.

## What's new

**`.github/workflows/tests.yml`** — on push to `master` and on every PR:

- Installs the project's documented Linux dependencies (`python3-wxgtk4.0`, `python3-serial`, `python3-requests`) via apt against the **system Python** (3.12 on `ubuntu-latest`). This mirrors the README's Linux install path and sidesteps the `setup-python` ↔ apt-wxPython interpreter mismatch that makes wxPython flaky to `pip install` on Linux.
- Runs the full suite under `xvfb-run` — `gui_themes` / `gui_main` import `wx.adv`, so a display must exist even to import them headlessly.

With wxPython, pyserial, and requests all present, the previously skipped GUI/theme/i18n tests **actually execute** in CI instead of self-skipping — so all 128 tests gate every change, not just the 120 non-GUI ones.

Also adds a **Tests** status badge to the README.

- `concurrency` cancels superseded runs per branch/PR.
- `permissions: contents: read` — least privilege, matching the existing release workflow.

## Testing

Locally (no wxPython): `python3 tests.py` → 128 passed, 8 skipped (the GUI/theme tests). In CI those 8 will run rather than skip because wxPython is installed and a display is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_