### PR TITLE
Extract workflow state machine from gui_main into gui_workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Only the latest push per branch/PR needs to run; cancel superseded runs.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the system Python (3.12 on ubuntu-latest) together with the
+      # apt-packaged dependencies — this mirrors the project's documented
+      # Linux install path (README) and avoids the setup-python / apt-wxPython
+      # interpreter mismatch. With wxPython, pyserial, and requests all present
+      # the GUI/theme/i18n tests actually run instead of self-skipping.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3-wxgtk4.0 \
+            python3-serial \
+            python3-requests \
+            xvfb
+
+      - name: Show environment
+        run: |
+          python3 --version
+          python3 -c "import wx, serial, requests; print('wx', wx.__version__)"
+
+      # gui_themes / gui_main import wx.adv, so a display must exist even to
+      # import them; xvfb-run supplies a headless one.
+      - name: Run test suite
+        run: xvfb-run -a python3 tests.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlintWave Flash
 
+[![Tests](https://github.com/FlintWave/flintwave-kdh-flasher/actions/workflows/tests.yml/badge.svg)](https://github.com/FlintWave/flintwave-kdh-flasher/actions/workflows/tests.yml)
+
 A cross-platform tool for flashing `.kdhx` firmware to radios that use the KDH bootloader — BTECH, Baofeng, Radtel, and others. Works on Linux, macOS, and Windows.
 
 Maintained by [FlintWave Radio Tools](https://github.com/FlintWave). Contact: flintwave@tuta.com

--- a/gui_main.py
+++ b/gui_main.py
@@ -28,6 +28,12 @@ from gui_dialogs import (
     show_test_report_dialog,
 )
 from gui_themes import apply_theme, THEME_PALETTES, MOCHA_PALETTE
+from gui_workflow import (
+    compute_hint_state,
+    compute_gates,
+    HINT_STATES as WORKFLOW_HINT_STATES,
+    RADIO_INFO_STATES,
+)
 
 VERSION = "26.07.0"
 
@@ -1085,11 +1091,14 @@ class FlasherFrame(wx.Frame):
         radio_chosen = self._get_selected_radio() is not None
         firmware = self._firmware_ready()
         handset = self._handset_ready()
+        gates = compute_gates(radio_chosen=radio_chosen,
+                              firmware_ready=firmware,
+                              handset_ready=handset)
 
         # Firmware column: Download requires a real radio. Browse is always
         # available (user may already have a .kdhx on disk).
         try:
-            self.download_btn.Enable(radio_chosen)
+            self.download_btn.Enable(gates.download)
         except Exception:
             pass
 
@@ -1097,13 +1106,13 @@ class FlasherFrame(wx.Frame):
         for w in (self.refresh_btn, self.select_all_btn, self.select_none_btn,
                   self.handset_list):
             try:
-                w.Enable(firmware)
+                w.Enable(gates.handset)
             except Exception:
                 pass
         # Flash column gate
         for w in (self.flash_btn, self.dryrun_btn, self.diag_btn):
             try:
-                w.Enable(firmware and handset)
+                w.Enable(gates.flash)
             except Exception:
                 pass
 
@@ -1258,11 +1267,9 @@ class FlasherFrame(wx.Frame):
     # from the active translation catalog by _get_hint_copy(); keeping this as a
     # set rather than a dict-of-strings means language changes are picked up
     # without rebuilding any structures.
-    HINT_STATES = {
-        "no_firmware", "no_handset", "batch_ready", "ready_dryrun",
-        "ready_flash", "downloading", "flashing", "dryrun", "diagnostics",
-        "complete", "dryrun_complete", "diag_complete", "failed",
-    }
+    # Source of truth lives in gui_workflow so the pure logic and its tests
+    # share one definition.
+    HINT_STATES = WORKFLOW_HINT_STATES
 
     def _get_hint_copy(self, state):
         """Return (title, body) for a hint state in the active language."""
@@ -1271,9 +1278,9 @@ class FlasherFrame(wx.Frame):
         return (t(f"hint.{state}.title"), t(f"hint.{state}.body"))
 
     # States during which it's useful to also show the per-radio info
-    # (bootloader keys, connector type, notes from radios.json).
-    _RADIO_INFO_STATES = {"no_firmware", "no_handset", "ready_flash",
-                          "ready_dryrun", "batch_ready"}
+    # (bootloader keys, connector type, notes from radios.json). Defined in
+    # gui_workflow alongside the state machine that produces these keys.
+    _RADIO_INFO_STATES = RADIO_INFO_STATES
 
     def _format_radio_info(self):
         """Return per-radio instructions for the active radio, or empty string."""
@@ -1346,21 +1353,18 @@ class FlasherFrame(wx.Frame):
             self.hint_text.Thaw()
 
     def _compute_hint_state(self):
-        if self._terminal_state in ("complete", "failed",
-                                    "dryrun_complete", "diag_complete"):
-            return self._terminal_state
-        if self._busy:
-            return self._busy_state if hasattr(self, "_busy_state") else "flashing"
-        # Use _firmware_ready() (path present AND file exists) so the hint
-        # can't advance to "ready to flash" while the Flash button stays
-        # disabled because the referenced file is missing/deleted.
-        if not self._firmware_ready():
-            return "no_firmware"
-        if not self._selected_handset_indices():
-            return "no_handset"
-        if len(self._selected_handset_indices()) > 1:
-            return "batch_ready"
-        return "ready_flash"
+        # Pure decision logic lives in gui_workflow.compute_hint_state; this
+        # method only reads the current values off the frame. _firmware_ready()
+        # checks path-present AND file-exists so the hint can't advance to
+        # "ready to flash" while the Flash button stays disabled because the
+        # referenced file is missing/deleted.
+        return compute_hint_state(
+            terminal_state=self._terminal_state,
+            busy=self._busy,
+            firmware_ready=self._firmware_ready(),
+            handset_count=len(self._selected_handset_indices()),
+            busy_state=getattr(self, "_busy_state", "flashing"),
+        )
 
     def _on_state_change(self, event):
         # User-initiated change clears any sticky terminal state

--- a/gui_workflow.py
+++ b/gui_workflow.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Pure workflow-state logic for the flasher GUI.
+
+The three-column BalenaEtcher-style workflow (Firmware → Handset → Flash) has
+two decision points that used to live as methods on the 2,300-line
+``FlasherFrame`` god-class, tangled together with wxWidgets calls:
+
+  * which *hint* to show the user (the instructions panel copy), and
+  * which column controls should be *enabled* (workflow gating).
+
+Both are pure functions of a handful of booleans/counts — no wx involved — so
+they live here where they can be unit-tested without a display or wxPython.
+``gui_main`` imports these and keeps only the widget wiring (reading values off
+controls, calling ``.Enable()`` / rendering text).
+"""
+
+from collections import namedtuple
+
+# Terminal states are sticky: once a flash/dry-run/diagnostics run finishes, the
+# hint stays on the outcome until the user changes something.
+TERMINAL_STATES = ("complete", "failed", "dryrun_complete", "diag_complete")
+
+# Every hint key the instructions panel knows how to render (matches the
+# hint.<state>.title / hint.<state>.body entries in the i18n catalogs).
+HINT_STATES = frozenset({
+    "no_firmware", "no_handset", "batch_ready", "ready_dryrun",
+    "ready_flash", "downloading", "flashing", "dryrun", "diagnostics",
+    "complete", "dryrun_complete", "diag_complete", "failed",
+})
+
+# States during which it's useful to also show the per-radio info (bootloader
+# keys, connector type, notes from radios.json) beneath the hint body.
+RADIO_INFO_STATES = frozenset({
+    "no_firmware", "no_handset", "ready_flash", "ready_dryrun", "batch_ready",
+})
+
+# Which column controls should be enabled at a given moment. The frame maps
+# these booleans onto the actual widgets.
+WorkflowGates = namedtuple("WorkflowGates", ["download", "handset", "flash"])
+
+
+def compute_hint_state(terminal_state, busy, firmware_ready, handset_count,
+                       busy_state="flashing"):
+    """Return the hint-state key for the current workflow situation.
+
+    Priority order (highest first):
+      1. A sticky terminal outcome (complete/failed/…) — show it until cleared.
+      2. An in-progress operation — show ``busy_state`` (downloading/flashing/…).
+      3. No firmware chosen yet — ``no_firmware``.
+      4. No handset checked — ``no_handset``.
+      5. More than one handset checked — ``batch_ready``.
+      6. Otherwise ready for a single flash — ``ready_flash``.
+    """
+    if terminal_state in TERMINAL_STATES:
+        return terminal_state
+    if busy:
+        return busy_state
+    if not firmware_ready:
+        return "no_firmware"
+    if handset_count == 0:
+        return "no_handset"
+    if handset_count > 1:
+        return "batch_ready"
+    return "ready_flash"
+
+
+def compute_gates(radio_chosen, firmware_ready, handset_ready):
+    """Return which column controls should be enabled.
+
+    Workflow tiers:
+      * Download needs a real radio selected (Browse is always available).
+      * The Handset column unlocks once a firmware file exists.
+      * The Flash column unlocks once firmware exists AND a handset is checked.
+    """
+    return WorkflowGates(
+        download=bool(radio_chosen),
+        handset=bool(firmware_ready),
+        flash=bool(firmware_ready) and bool(handset_ready),
+    )

--- a/tests.py
+++ b/tests.py
@@ -1271,5 +1271,87 @@ class TestBatchFlashRouting(unittest.TestCase):
         self.assertEqual(eng_b.reassembled_firmware(), pad)
 
 
+class TestWorkflowStateMachine(unittest.TestCase):
+    """Pure workflow logic extracted from FlasherFrame (gui_workflow).
+
+    These run with no wxPython and no display — the whole point of pulling the
+    hint/gating decisions out of the GUI god-class is that they're now testable
+    in isolation.
+    """
+
+    def setUp(self):
+        import gui_workflow
+        self.w = gui_workflow
+
+    def test_terminal_state_is_sticky(self):
+        for state in ("complete", "failed", "dryrun_complete", "diag_complete"):
+            # A terminal state wins even over busy / firmware / handset inputs.
+            self.assertEqual(
+                self.w.compute_hint_state(state, True, True, 5), state)
+
+    def test_busy_reports_busy_state(self):
+        self.assertEqual(
+            self.w.compute_hint_state(None, True, True, 1), "flashing")
+        self.assertEqual(
+            self.w.compute_hint_state(None, True, True, 1,
+                                      busy_state="downloading"), "downloading")
+
+    def test_no_firmware_before_anything_else(self):
+        self.assertEqual(
+            self.w.compute_hint_state(None, False, False, 0), "no_firmware")
+        # No firmware outranks having handsets checked.
+        self.assertEqual(
+            self.w.compute_hint_state(None, False, False, 3), "no_firmware")
+
+    def test_no_handset_when_firmware_ready_but_none_checked(self):
+        self.assertEqual(
+            self.w.compute_hint_state(None, False, True, 0), "no_handset")
+
+    def test_single_vs_batch(self):
+        self.assertEqual(
+            self.w.compute_hint_state(None, False, True, 1), "ready_flash")
+        self.assertEqual(
+            self.w.compute_hint_state(None, False, True, 2), "batch_ready")
+
+    def test_every_state_is_a_known_hint_key(self):
+        # Any state the machine can emit must have a hint.<state>.* entry.
+        produced = {
+            self.w.compute_hint_state(None, False, False, 0),
+            self.w.compute_hint_state(None, False, True, 0),
+            self.w.compute_hint_state(None, False, True, 1),
+            self.w.compute_hint_state(None, False, True, 2),
+            self.w.compute_hint_state(None, True, True, 1, busy_state="downloading"),
+            self.w.compute_hint_state(None, True, True, 1, busy_state="flashing"),
+        }
+        produced |= set(self.w.TERMINAL_STATES)
+        self.assertTrue(produced <= set(self.w.HINT_STATES),
+                        f"unknown hint keys: {produced - set(self.w.HINT_STATES)}")
+
+    def test_gates_download_needs_radio(self):
+        g = self.w.compute_gates(radio_chosen=False, firmware_ready=True,
+                                 handset_ready=True)
+        self.assertFalse(g.download)
+        g = self.w.compute_gates(radio_chosen=True, firmware_ready=False,
+                                 handset_ready=False)
+        self.assertTrue(g.download)
+
+    def test_gates_handset_needs_firmware(self):
+        self.assertFalse(self.w.compute_gates(True, False, True).handset)
+        self.assertTrue(self.w.compute_gates(True, True, False).handset)
+
+    def test_gates_flash_needs_firmware_and_handset(self):
+        self.assertFalse(self.w.compute_gates(True, True, False).flash)
+        self.assertFalse(self.w.compute_gates(True, False, True).flash)
+        self.assertTrue(self.w.compute_gates(True, True, True).flash)
+
+    def test_gates_return_plain_bools(self):
+        # Frame passes truthy objects (e.g. a radio dict); gates must normalize.
+        g = self.w.compute_gates(radio_chosen={"id": "x"}, firmware_ready=1,
+                                 handset_ready=[0])
+        self.assertIs(g.download, True)
+        self.assertIs(g.handset, True)
+        self.assertIs(g.flash, True)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

First slice of decomposing the 2,300-line `FlasherFrame` god-class in `gui_main.py`. This one is deliberately small and low-risk — it establishes the pattern (pull pure logic out into a wx-free, unit-tested module) without touching the wx widget tree.

The three-column workflow (Firmware → Handset → Flash) has two pure decision points that were trapped as methods on the frame, interleaved with wx calls and therefore only reachable with a live display:

- **which hint to show** the user in the instructions panel, and
- **which column controls should be enabled** (workflow gating).

Both are pure functions of a few booleans/counts. This PR moves that logic into a new **`gui_workflow.py`**:

- `compute_hint_state(terminal_state, busy, firmware_ready, handset_count, busy_state)` → the hint-state key
- `compute_gates(radio_chosen, firmware_ready, handset_ready)` → a `WorkflowGates(download, handset, flash)` triple
- `HINT_STATES` / `RADIO_INFO_STATES` / `TERMINAL_STATES` constants (single source of truth)

`gui_main` now just reads values off its widgets and delegates the decisions; `FlasherFrame.HINT_STATES` / `_RADIO_INFO_STATES` alias the module constants, so every existing reference — and the i18n-completeness test that iterates `FlasherFrame.HINT_STATES` — is unchanged.

## Why this ordering

`gui_main.py` is the one real architectural smell in an otherwise tidy codebase (~90 methods on one class). Extracting the *pure* logic first is the safe way in: it's verifiable headlessly (no display needed), it shrinks the class, and it gives regression coverage before any of the riskier wx-panel component extractions (title bar, status bar, the three column builders) that come next.

## Behavior

Identical. Verified by:
- direct parity checks against the original method logic, and
- **10 new unit tests** (`TestWorkflowStateMachine`) that run with no wxPython — covering terminal-state stickiness, busy states, the firmware/handset gating order, single-vs-batch, gate normalization to plain bools, and that every emitted state is a known hint key.

`python3 tests.py` → **138 passed** (was 128), 8 skipped (GUI/theme tests needing wxPython, which run in CI).

## Follow-ups (not in this PR)

Subsequent slices, each its own PR kept green by the CI gate: extract the custom title bar + drag handling, the status bar (theme/font/language controls), and the three workflow-column builders into component classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_