### PR TITLE
Extract custom title bar from gui_main into a TitleBar component

### DIFF
--- a/gui_main.py
+++ b/gui_main.py
@@ -34,6 +34,7 @@ from gui_workflow import (
     HINT_STATES as WORKFLOW_HINT_STATES,
     RADIO_INFO_STATES,
 )
+from gui_titlebar import TitleBar
 
 VERSION = "26.07.0"
 
@@ -104,7 +105,7 @@ class FlasherFrame(wx.Frame):
         root_sizer = wx.BoxSizer(wx.VERTICAL)
 
         # ---- Custom title bar (replaces OS chrome) ----
-        self.title_bar = self._build_title_bar(panel)
+        self.title_bar = TitleBar(panel, self)
         root_sizer.Add(self.title_bar, 0, wx.EXPAND)
 
         # ---- Top row: three columns separated by ">" arrows ----
@@ -433,9 +434,11 @@ class FlasherFrame(wx.Frame):
             self.SetTitle(t("app.title"))
         except Exception:
             pass
-        if hasattr(self, "title_label") and self.title_label is not None:
+        title_bar = getattr(self, "title_bar", None)
+        title_label = getattr(title_bar, "title_label", None)
+        if title_label is not None:
             try:
-                self.title_label.SetLabel(t("app.title"))
+                title_label.SetLabel(t("app.title"))
             except Exception:
                 pass
 
@@ -678,96 +681,6 @@ class FlasherFrame(wx.Frame):
         col.SetSizer(sizer)
         self._rtl_targets.append(col)
         return col
-
-    def _build_title_bar(self, parent):
-        """Custom borderless title bar with app title + minimize/close.
-
-        We removed the OS title bar so the chrome themes consistently with the
-        rest of the app. Drag the title bar (or title label / icon) to move
-        the window. No maximize button (per user preference).
-        """
-        bar = wx.Panel(parent)
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-
-        # App icon at far left (small, scaled from icon_128).
-        icon_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                 "icon_128.png")
-        if os.path.exists(icon_path):
-            img = wx.Image(icon_path).Rescale(20, 20, wx.IMAGE_QUALITY_HIGH)
-            self._title_icon = wx.StaticBitmap(bar, bitmap=wx.Bitmap(img))
-            sizer.Add(self._title_icon, 0,
-                      wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 8)
-        else:
-            self._title_icon = None
-
-        self.title_label = wx.StaticText(bar, label=self.GetTitle())
-        title_font = wx.Font(self.font_size, wx.FONTFAMILY_DEFAULT,
-                             wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
-        self.title_label.SetFont(title_font)
-        sizer.Add(self.title_label, 0,
-                  wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
-
-        sizer.AddStretchSpacer(1)
-
-        # The language picker used to live here as a wx.Choice dropdown; it
-        # was moved to the status bar in v26.05.5 so the title bar stays
-        # focused on identity (icon + title) and window controls only.
-
-        def make_chrome_btn(label, tooltip_key, handler):
-            b = wx.StaticText(bar, label=label)
-            b.SetCursor(wx.Cursor(wx.CURSOR_HAND))
-            b.SetToolTip(t(tooltip_key))
-            self._tr_tooltip(b, tooltip_key)
-            b.Bind(wx.EVT_LEFT_DOWN, lambda e: handler())
-            chrome_font = wx.Font(self.font_size + 2, wx.FONTFAMILY_DEFAULT,
-                                  wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
-            b.SetFont(chrome_font)
-            return b
-
-        self._minimize_btn = make_chrome_btn("—", "titlebar.minimize_tooltip", self.Iconize)
-        self._close_btn = make_chrome_btn("✕", "titlebar.close_tooltip", self.Close)
-        sizer.Add(self._minimize_btn, 0,
-                  wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        sizer.Add(self._close_btn, 0,
-                  wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-
-        bar.SetSizer(sizer)
-        bar.SetMinSize(wx.Size(-1, 36))
-        self._rtl_targets.append(bar)
-
-        # Drag-to-move on title bar background, the title label, and the icon.
-        for w in (bar, self.title_label):
-            w.Bind(wx.EVT_LEFT_DOWN, self._on_titlebar_press)
-            w.Bind(wx.EVT_MOTION, self._on_titlebar_drag)
-            w.Bind(wx.EVT_LEFT_UP, self._on_titlebar_release)
-        if self._title_icon is not None:
-            self._title_icon.Bind(wx.EVT_LEFT_DOWN, self._on_titlebar_press)
-            self._title_icon.Bind(wx.EVT_MOTION, self._on_titlebar_drag)
-            self._title_icon.Bind(wx.EVT_LEFT_UP, self._on_titlebar_release)
-
-        self._drag_offset = None
-        return bar
-
-    def _on_titlebar_press(self, event):
-        """Start a drag-to-move from the title bar."""
-        # Capture the offset between mouse and window's top-left so we can
-        # subtract it from each subsequent mouse position to compute the
-        # window's new origin.
-        self._drag_offset = wx.GetMousePosition() - self.GetPosition()
-        w = event.GetEventObject()
-        if not w.HasCapture():
-            w.CaptureMouse()
-
-    def _on_titlebar_drag(self, event):
-        if (event.Dragging() and event.LeftIsDown()
-                and self._drag_offset is not None):
-            self.Move(wx.GetMousePosition() - self._drag_offset)
-
-    def _on_titlebar_release(self, event):
-        w = event.GetEventObject()
-        if w.HasCapture():
-            w.ReleaseMouse()
-        self._drag_offset = None
 
     def _build_status_bar(self, parent):
         """Borderless status bar with text/icon click-targets (no button frames)."""

--- a/gui_titlebar.py
+++ b/gui_titlebar.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Custom borderless title bar component.
+
+Extracted from the FlasherFrame god-class: the app removes the OS title bar so
+the window chrome themes consistently with the rest of the UI, and this panel
+supplies the replacement — app icon, title label, and minimize/close controls,
+with drag-to-move on the bar / title / icon.
+
+``TitleBar`` collaborates with the owning frame for the handful of things only
+the frame can provide: the window operations it drives (``GetTitle``, ``Iconize``,
+``Close``, and — via ``WindowDragger`` — ``Move`` / ``GetPosition``), the current
+font size, and the frame's live-retranslation (``_tr_tooltip``) and RTL-mirroring
+(``_rtl_targets``) registries so language switches keep working.
+
+The module guards its ``wx`` import so the pure ``WindowDragger`` (re-exported for
+convenience) and this module stay importable in a headless / pyserial-free test
+environment; ``TitleBar`` itself is only defined when wx is present.
+"""
+
+import os
+
+from window_drag import WindowDragger
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+
+if wx is not None:
+
+    class TitleBar(wx.Panel):
+        """Borderless title bar: icon + title, minimize/close, drag-to-move."""
+
+        def __init__(self, parent, frame):
+            super().__init__(parent)
+            self._frame = frame
+            self._dragger = WindowDragger(frame, wx.GetMousePosition)
+            self.title_icon = None
+            self.title_label = None
+            self._build()
+
+        def _build(self):
+            frame = self._frame
+            sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+            # App icon at far left (small, scaled from icon_128).
+            icon_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                     "icon_128.png")
+            if os.path.exists(icon_path):
+                img = wx.Image(icon_path).Rescale(20, 20, wx.IMAGE_QUALITY_HIGH)
+                self.title_icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(img))
+                sizer.Add(self.title_icon, 0,
+                          wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 8)
+
+            self.title_label = wx.StaticText(self, label=frame.GetTitle())
+            title_font = wx.Font(frame.font_size, wx.FONTFAMILY_DEFAULT,
+                                 wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+            self.title_label.SetFont(title_font)
+            sizer.Add(self.title_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
+
+            sizer.AddStretchSpacer(1)
+
+            # The language picker used to live here; it moved to the status bar
+            # in v26.05.5 so the title bar stays focused on identity + window
+            # controls only.
+            self._minimize_btn = self._make_chrome_btn(
+                "—", "titlebar.minimize_tooltip", frame.Iconize)
+            self._close_btn = self._make_chrome_btn(
+                "✕", "titlebar.close_tooltip", frame.Close)
+            sizer.Add(self._minimize_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            sizer.Add(self._close_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+
+            self.SetSizer(sizer)
+            self.SetMinSize(wx.Size(-1, 36))
+            frame._rtl_targets.append(self)
+
+            # Drag-to-move on the bar background, the title label, and the icon.
+            for w in (self, self.title_label):
+                self._bind_drag(w)
+            if self.title_icon is not None:
+                self._bind_drag(self.title_icon)
+
+        def _make_chrome_btn(self, label, tooltip_key, handler):
+            b = wx.StaticText(self, label=label)
+            b.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+            # _tr_tooltip both sets the tooltip now and registers it for live
+            # retranslation on language change.
+            self._frame._tr_tooltip(b, tooltip_key)
+            b.Bind(wx.EVT_LEFT_DOWN, lambda e: handler())
+            chrome_font = wx.Font(self._frame.font_size + 2, wx.FONTFAMILY_DEFAULT,
+                                  wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+            b.SetFont(chrome_font)
+            return b
+
+        def _bind_drag(self, w):
+            w.Bind(wx.EVT_LEFT_DOWN, self._on_press)
+            w.Bind(wx.EVT_MOTION, self._on_drag)
+            w.Bind(wx.EVT_LEFT_UP, self._on_release)
+
+        def _on_press(self, event):
+            self._dragger.begin()
+            w = event.GetEventObject()
+            if not w.HasCapture():
+                w.CaptureMouse()
+
+        def _on_drag(self, event):
+            if event.Dragging() and event.LeftIsDown():
+                self._dragger.drag()
+
+        def _on_release(self, event):
+            w = event.GetEventObject()
+            if w.HasCapture():
+                w.ReleaseMouse()
+            self._dragger.end()
+
+else:  # pragma: no cover - exercised only in wx-less test environments
+    TitleBar = None

--- a/tests.py
+++ b/tests.py
@@ -1353,5 +1353,93 @@ class TestWorkflowStateMachine(unittest.TestCase):
         self.assertIs(g.flash, True)
 
 
+class TestWindowDragger(unittest.TestCase):
+    """Drag-to-move math extracted from the title bar (window_drag).
+
+    Pure arithmetic, no wxWidgets — driven here with plain vector objects and a
+    fake window so the borderless-window drag behavior is testable headlessly.
+    """
+
+    class Vec:
+        __slots__ = ("x", "y")
+
+        def __init__(self, x, y):
+            self.x, self.y = x, y
+
+        def __add__(self, o):
+            return TestWindowDragger.Vec(self.x + o.x, self.y + o.y)
+
+        def __sub__(self, o):
+            return TestWindowDragger.Vec(self.x - o.x, self.y - o.y)
+
+        def __eq__(self, o):
+            return isinstance(o, TestWindowDragger.Vec) and (self.x, self.y) == (o.x, o.y)
+
+        def __repr__(self):
+            return f"Vec({self.x}, {self.y})"
+
+    class FakeWindow:
+        def __init__(self, pos):
+            self.pos = pos
+            self.move_calls = 0
+
+        def GetPosition(self):
+            return self.pos
+
+        def Move(self, p):
+            self.pos = p
+            self.move_calls += 1
+
+    def setUp(self):
+        from window_drag import WindowDragger
+        self.WindowDragger = WindowDragger
+        self.mouse = self.Vec(0, 0)
+        self.win = self.FakeWindow(self.Vec(100, 100))
+        self.dragger = WindowDragger(self.win, lambda: self.mouse)
+
+    def test_inactive_until_begin(self):
+        self.assertFalse(self.dragger.active)
+
+    def test_drag_follows_pointer_delta(self):
+        self.mouse = self.Vec(120, 110)     # grab 20,10 into the window
+        self.dragger.begin()
+        self.assertTrue(self.dragger.active)
+        self.mouse = self.Vec(150, 115)     # pointer moves +30,+5
+        self.dragger.drag()
+        self.assertEqual(self.win.pos, self.Vec(130, 105))
+        self.mouse = self.Vec(90, 90)       # pointer moves to a new spot
+        self.dragger.drag()
+        self.assertEqual(self.win.pos, self.Vec(70, 80))
+
+    def test_drag_before_begin_is_noop(self):
+        self.mouse = self.Vec(500, 500)
+        self.dragger.drag()
+        self.assertEqual(self.win.move_calls, 0)
+        self.assertEqual(self.win.pos, self.Vec(100, 100))
+
+    def test_drag_after_end_is_noop(self):
+        self.mouse = self.Vec(120, 110)
+        self.dragger.begin()
+        self.dragger.end()
+        self.assertFalse(self.dragger.active)
+        calls_before = self.win.move_calls
+        self.mouse = self.Vec(999, 999)
+        self.dragger.drag()
+        self.assertEqual(self.win.move_calls, calls_before)
+
+
+class TestTitleBarModule(unittest.TestCase):
+    """gui_titlebar import contract (component tested via wx in CI)."""
+
+    def test_module_imports_and_exposes_titlebar(self):
+        # Importable even without wxPython; TitleBar is a class when wx is
+        # present (CI) and None otherwise (headless dev). WindowDragger is
+        # re-usable regardless.
+        import gui_titlebar
+        self.assertTrue(hasattr(gui_titlebar, "TitleBar"))
+        from window_drag import WindowDragger
+        self.assertIs(gui_titlebar.WindowDragger, WindowDragger)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/window_drag.py
+++ b/window_drag.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Drag-to-move helper for borderless windows.
+
+The app hides the OS title bar and provides its own, so moving the window is
+done by dragging the custom title bar. The offset bookkeeping — capture where
+the mouse grabbed the window, then keep the window at (mouse - offset) as the
+mouse moves — is pure arithmetic with no wxWidgets in it, so it lives here where
+it can be unit-tested without a display.
+
+``WindowDragger`` talks to the window only through ``GetPosition()`` / ``Move()``
+and gets the pointer location from an injected callable, so tests can drive it
+with plain vector objects. The wx-specific bits (mouse capture, event filtering)
+stay in the ``TitleBar`` component that owns the dragger.
+"""
+
+
+class WindowDragger:
+    """Tracks a drag-to-move gesture for ``window``.
+
+    Args:
+        window: object with ``GetPosition()`` and ``Move(pos)`` (a wx.Frame in
+            production). Positions are whatever ``get_mouse_pos`` returns and
+            ``window.GetPosition()`` yields — they only need ``+`` / ``-``.
+        get_mouse_pos: zero-arg callable returning the current pointer position
+            (``wx.GetMousePosition`` in production).
+    """
+
+    def __init__(self, window, get_mouse_pos):
+        self._window = window
+        self._get_mouse_pos = get_mouse_pos
+        self._offset = None
+
+    def begin(self):
+        """Record the mouse-to-window offset at the start of a drag."""
+        self._offset = self._get_mouse_pos() - self._window.GetPosition()
+
+    def drag(self):
+        """Move the window so the grab point stays under the pointer.
+
+        No-op if a drag isn't in progress, so it's safe to call on every mouse
+        motion event.
+        """
+        if self._offset is not None:
+            self._window.Move(self._get_mouse_pos() - self._offset)
+
+    def end(self):
+        """Finish the drag; subsequent ``drag()`` calls do nothing until begin()."""
+        self._offset = None
+
+    @property
+    def active(self):
+        """True while a drag is in progress."""
+        return self._offset is not None


### PR DESCRIPTION
## Summary

Second slice of decomposing the `FlasherFrame` god-class (after #15's workflow-state extraction). This one moves the custom borderless **title bar** — app icon + title label, minimize/close chrome, and drag-to-move — out of the frame into its own component, plus a reusable, unit-tested drag helper.

## What moved

**`window_drag.py`** — a pure, wx-free `WindowDragger` that owns the drag-to-move *offset math*: record the mouse-to-window offset on press, then keep the window at `mouse − offset` on each motion. No wx, so it's unit-testable with plain vector objects and a fake window — no display needed. The wx-specific bits (mouse capture, event filtering) stay in the component.

**`gui_titlebar.py`** — a `TitleBar(wx.Panel)` component that builds the widgets and wires the drag through `WindowDragger`. It collaborates with the owning frame for the handful of things only the frame provides:
- the window ops it drives — `GetTitle` / `Iconize` / `Close`, and via the dragger `Move` / `GetPosition`
- the current font size
- the frame's live-retranslation (`_tr_tooltip`) and RTL-mirroring (`_rtl_targets`) registries, so language switching keeps working

`gui_main` now just does `self.title_bar = TitleBar(panel, self)`, and `retranslate_ui` reads the label off the component. The four old builder/handler methods (`_build_title_bar`, `_on_titlebar_press/drag/release`) are gone — **`gui_main.py` drops ~90 lines**.

## Headless-safety

`gui_titlebar` guards its `wx` import: the module (and the re-exported `WindowDragger`) stay importable with no wxPython installed, so the test suite loads it anywhere. `TitleBar` is `None` in that case; the real widget is exercised in CI, where wxPython is present.

## Behavior

Unchanged — same widgets, same drag feel, same theming (the component's widgets sit at the same nesting depth, so the recursive theme pass still reaches them), same retranslation/RTL wiring.

Verified by **5 new unit tests** (138 → 143): drag follows the pointer delta, is a no-op before `begin()` and after `end()`, and the module import contract. `python3 tests.py` → 143 passed, 8 skipped (GUI tests needing wxPython, which run in CI).

## Roadmap

Remaining `gui_main` slices, each its own CI-gated PR:
- ✅ workflow state machine → `gui_workflow` (#15)
- ✅ **custom title bar → `TitleBar` (this PR)**
- status bar (theme / font / language controls) → component
- the three column builders → panel classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_