### PR TITLE
Extract status bar from gui_main into a StatusBar component

### DIFF
--- a/gui_main.py
+++ b/gui_main.py
@@ -35,6 +35,7 @@ from gui_workflow import (
     RADIO_INFO_STATES,
 )
 from gui_titlebar import TitleBar
+from gui_statusbar import StatusBar, theme_toggle_glyph
 
 VERSION = "26.07.0"
 
@@ -209,7 +210,13 @@ class FlasherFrame(wx.Frame):
         root_sizer.Add(middle_row, 1, wx.EXPAND)
 
         # ---- Bottom status bar: borderless text/icon links, darker background ----
-        self.status_bar_panel = self._build_status_bar(panel)
+        self.status_bar_panel = StatusBar(panel, self)
+        # Keep frame-level handles to the widgets the frame updates directly
+        # (font/theme/lang labels, the update-available link).
+        self.font_btn = self.status_bar_panel.font_btn
+        self.theme_btn = self.status_bar_panel.theme_btn
+        self.lang_btn = self.status_bar_panel.lang_btn
+        self.update_link = self.status_bar_panel.update_link
         root_sizer.Add(self.status_bar_panel, 0, wx.EXPAND)
 
         panel.SetSizer(root_sizer)
@@ -682,76 +689,12 @@ class FlasherFrame(wx.Frame):
         self._rtl_targets.append(col)
         return col
 
-    def _build_status_bar(self, parent):
-        """Borderless status bar with text/icon click-targets (no button frames)."""
-        bar = wx.Panel(parent)
-        bar_sizer = wx.BoxSizer(wx.HORIZONTAL)
-
-        def make_link(label, tooltip_key, handler, label_key=None):
-            """Create a clickable StaticText (no button border)."""
-            link = wx.StaticText(bar, label=label)
-            link.SetCursor(wx.Cursor(wx.CURSOR_HAND))
-            link.SetToolTip(t(tooltip_key))
-            self._tr_tooltip(link, tooltip_key)
-            if label_key is not None:
-                self._tr_label(link, label_key)
-            link.Bind(wx.EVT_LEFT_DOWN, lambda e: handler())
-            return link
-
-        self.font_btn = make_link(
-            f"{self.font_size}pt", "tooltip.font_cycle", self._cycle_font)
-
-        # Theme toggle: glyph reflects the destination — sun = "switch to light",
-        # moon = "switch to dark". Currently mocha (dark) → show sun.
-        self.theme_btn = make_link(
-            "☀" if self.current_theme == "mocha" else "☾",
-            "tooltip.theme_toggle", self._toggle_theme)
-
-        # Language picker (was a title-bar dropdown pre-v26.05.5). Click opens
-        # a modal listing every supported language with its native-script
-        # label; the button itself shows the current language so users always
-        # see which one is active.
-        self.lang_btn = make_link(
-            self._language_button_label(),
-            "tooltip.language", self._open_language_dialog)
-
-        usage_link = make_link(t("statusbar.usage"), "tooltip.usage",
-                               lambda: self.on_usage_guide(None),
-                               label_key="statusbar.usage")
-        about_link = make_link(t("statusbar.about"), "tooltip.about",
-                               lambda: self.on_about(None),
-                               label_key="statusbar.about")
-
-        # Hidden hyperlink: when _check_update finds a newer release we set
-        # its URL and Show() it. Click opens the releases page.
-        self.update_link = wx.adv.HyperlinkCtrl(
-            bar, label=t("statusbar.update_available"),
-            url="https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest",
-            style=wx.adv.HL_ALIGN_LEFT | wx.NO_BORDER)
-        self._tr_label(self.update_link, "statusbar.update_available")
-        self.update_link.Hide()
-
-        bar_sizer.AddSpacer(12)
-        bar_sizer.Add(self.font_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.Add(self.theme_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.Add(self.lang_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.AddStretchSpacer(1)
-        bar_sizer.Add(usage_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.Add(self.update_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.Add(about_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
-        bar_sizer.AddSpacer(4)
-
-        bar.SetSizer(bar_sizer)
-        bar.SetMinSize(wx.Size(-1, 32))
-        self._rtl_targets.append(bar)
-        return bar
-
     def _toggle_theme(self):
         """Switch between mocha (dark) and latte (light), re-render everything."""
         new_theme = "latte" if self.current_theme == "mocha" else "mocha"
         apply_theme(self, new_theme)
         # Re-glyph the toggle to point at the *next* destination.
-        self.theme_btn.SetLabel("☀" if self.current_theme == "mocha" else "☾")
+        self.theme_btn.SetLabel(theme_toggle_glyph(self.current_theme))
         # Force a repaint of every dialog-style child so they pick up the swap.
         self.panel.Layout()
         self.panel.Refresh()
@@ -2209,7 +2152,7 @@ def main():
     frame = FlasherFrame()
     initial_theme = detect_os_theme()
     frame.current_theme = initial_theme
-    frame.theme_btn.SetLabel("☀" if initial_theme == "mocha" else "☾")
+    frame.theme_btn.SetLabel(theme_toggle_glyph(initial_theme))
     frame.Show()
     apply_theme(frame, initial_theme)
     # Apply the default font size to every widget so the user gets 12pt UI on

--- a/gui_statusbar.py
+++ b/gui_statusbar.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Borderless status bar component.
+
+Extracted from the FlasherFrame god-class: the row of click-target "links"
+along the bottom of the window — font-size cycler, theme toggle, language
+picker on the left; usage guide, update-available link, and about on the right.
+
+The status bar is a *view*: it builds the widgets and routes their clicks to
+frame-level actions (``_cycle_font`` / ``_toggle_theme`` / ``_open_language_dialog``
+/ ``on_usage_guide`` / ``on_about``), which mutate app-wide state (fonts across
+every widget, the active theme, the language) and therefore stay on the frame.
+The frame still updates a few of these widgets directly (the font/theme/lang
+labels, showing the update link), so ``StatusBar`` exposes them as attributes and
+the frame keeps handles to them.
+
+Like ``gui_titlebar``, the ``wx`` import is guarded so the module and the pure
+``theme_toggle_glyph`` helper stay importable in a headless / pyserial-free test
+environment; ``StatusBar`` itself is only defined when wx is present.
+"""
+
+try:
+    import wx
+    import wx.adv
+except ImportError:
+    wx = None
+
+RELEASES_URL = "https://github.com/FlintWave/flintwave-kdh-flasher/releases/latest"
+
+
+def theme_toggle_glyph(current_theme):
+    """Glyph for the theme toggle — it points at the *destination* theme.
+
+    Dark (mocha) is active → show a sun (☀, "switch to light"); light (latte)
+    is active → show a moon (☾, "switch to dark"). Centralizes a choice that was
+    duplicated across the builder, the toggle handler, and the launch code.
+    """
+    return "☀" if current_theme == "mocha" else "☾"
+
+
+if wx is not None:
+
+    class StatusBar(wx.Panel):
+        """Row of click-target links: font / theme / language | usage / update / about."""
+
+        def __init__(self, parent, frame):
+            super().__init__(parent)
+            self._frame = frame
+            self._build()
+
+        def _make_link(self, label, tooltip_key, handler, label_key=None):
+            """A clickable StaticText (no button border), registered for i18n."""
+            link = wx.StaticText(self, label=label)
+            link.SetCursor(wx.Cursor(wx.CURSOR_HAND))
+            # _tr_tooltip sets the tooltip now and registers it for live
+            # retranslation on language change.
+            self._frame._tr_tooltip(link, tooltip_key)
+            if label_key is not None:
+                self._frame._tr_label(link, label_key)
+            link.Bind(wx.EVT_LEFT_DOWN, lambda e: handler())
+            return link
+
+        def _build(self):
+            frame = self._frame
+            from i18n import t
+
+            bar_sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+            self.font_btn = self._make_link(
+                f"{frame.font_size}pt", "tooltip.font_cycle", frame._cycle_font)
+
+            self.theme_btn = self._make_link(
+                theme_toggle_glyph(frame.current_theme),
+                "tooltip.theme_toggle", frame._toggle_theme)
+
+            # Language picker (was a title-bar dropdown pre-v26.05.5). Click
+            # opens a modal listing every supported language in its native
+            # script; the button shows the active language.
+            self.lang_btn = self._make_link(
+                frame._language_button_label(),
+                "tooltip.language", frame._open_language_dialog)
+
+            usage_link = self._make_link(
+                t("statusbar.usage"), "tooltip.usage",
+                lambda: frame.on_usage_guide(None), label_key="statusbar.usage")
+            about_link = self._make_link(
+                t("statusbar.about"), "tooltip.about",
+                lambda: frame.on_about(None), label_key="statusbar.about")
+
+            # Hidden hyperlink: when _check_update finds a newer release the
+            # frame sets its URL and Show()s it. Click opens the releases page.
+            self.update_link = wx.adv.HyperlinkCtrl(
+                self, label=t("statusbar.update_available"), url=RELEASES_URL,
+                style=wx.adv.HL_ALIGN_LEFT | wx.NO_BORDER)
+            frame._tr_label(self.update_link, "statusbar.update_available")
+            self.update_link.Hide()
+
+            bar_sizer.AddSpacer(12)
+            bar_sizer.Add(self.font_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.Add(self.theme_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.Add(self.lang_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.AddStretchSpacer(1)
+            bar_sizer.Add(usage_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.Add(self.update_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.Add(about_link, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 16)
+            bar_sizer.AddSpacer(4)
+
+            self.SetSizer(bar_sizer)
+            self.SetMinSize(wx.Size(-1, 32))
+            frame._rtl_targets.append(self)
+
+else:  # pragma: no cover - exercised only in wx-less test environments
+    StatusBar = None

--- a/tests.py
+++ b/tests.py
@@ -1441,5 +1441,27 @@ class TestTitleBarModule(unittest.TestCase):
         self.assertIs(gui_titlebar.WindowDragger, WindowDragger)
 
 
+class TestStatusBarModule(unittest.TestCase):
+    """Pure status-bar helpers + import contract (widget tested via wx in CI)."""
+
+    def setUp(self):
+        import gui_statusbar
+        self.s = gui_statusbar
+
+    def test_theme_toggle_glyph_points_at_destination(self):
+        # Dark active -> sun ("switch to light"); light active -> moon.
+        self.assertEqual(self.s.theme_toggle_glyph("mocha"), "☀")
+        self.assertEqual(self.s.theme_toggle_glyph("latte"), "☾")
+
+    def test_theme_toggle_glyph_defaults_to_moon_for_non_mocha(self):
+        # Anything that isn't the dark theme reads as "currently light".
+        self.assertEqual(self.s.theme_toggle_glyph("anything-else"), "☾")
+
+    def test_module_imports_and_exposes_statusbar(self):
+        # Importable without wxPython; StatusBar is a class in CI, None here.
+        self.assertTrue(hasattr(self.s, "StatusBar"))
+        self.assertTrue(self.s.RELEASES_URL.startswith("https://"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Third slice of decomposing the `FlasherFrame` god-class (after #15 workflow state, #16 title bar). This moves the borderless **status bar** — the row of click-target links at the bottom of the window — out of the frame into its own component.

## What moved

**`gui_statusbar.py`**:
- **`StatusBar(wx.Panel)`** builds the links (font-size cycler, theme toggle, language picker on the left; usage guide, update-available link, about on the right) and routes their clicks to the frame-level actions. Those actions (`_cycle_font` / `_toggle_theme` / `_open_language_dialog` / `on_usage_guide` / `on_about`) mutate **app-wide** state — fonts across every widget, the active theme, the language — so they correctly stay on the frame; the status bar is just the view. It uses the frame's i18n registries (`_tr_tooltip` / `_tr_label`) and RTL list so language switching keeps working.
- **`theme_toggle_glyph(current_theme)`** — a pure helper for the sun/moon glyph that reflects the toggle's *destination* theme (dark active → ☀ "switch to light"; light active → ☾). This de-duplicates a choice that was copy-pasted in three places (the builder, `_toggle_theme`, and the launch code).

## Design note

The frame still updates four of these widgets directly (the font/theme/lang labels, and showing the update link when a new release is found — ~10 call sites including module-level launch code). Rather than churn every one, `StatusBar` exposes those widgets and the frame keeps handles to them (`font_btn` / `theme_btn` / `lang_btn` / `update_link`). So **every existing call site is unchanged** — only the construction moved. `status_bar_panel` is now the component instance, so the existing `.Layout()` calls still work.

## Behavior

Identical — same links, same actions, same theming and retranslation/RTL wiring.

`gui_statusbar` guards its `wx` import so the module and the pure glyph helper load headlessly (`StatusBar` is `None` there); the real widget is exercised in CI where wxPython is present, via `gui_main`'s import path.

Verified by **3 new unit tests** (143 → 146): the glyph helper in both directions + a default, and the module import contract. `python3 tests.py` → 146 passed, 8 skipped (GUI tests needing wxPython, which run in CI). `gui_main.py` drops ~57 lines.

## Roadmap

- ✅ workflow state machine → `gui_workflow` (#15)
- ✅ custom title bar → `TitleBar` + `WindowDragger` (#16)
- ✅ **status bar → `StatusBar` (this PR)**
- the three column builders (`_build_firmware_column` / `_build_handset_column` / `_build_flash_column`) → panel classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_