### PR TITLE
Extract the three workflow columns from gui_main into gui_columns

### DIFF
--- a/gui_columns.py
+++ b/gui_columns.py
@@ -80,6 +80,9 @@ if wx is not None:
                 try:
                     self.radio_combo.Popup()
                 except Exception:
+                    # Best-effort UX: Popup() is unsupported on some wx
+                    # backends. Falling through still lets the native arrow
+                    # open the list, so a failure here is non-fatal.
                     pass
                 event.Skip()
             self.radio_combo.Bind(wx.EVT_LEFT_DOWN, _open_combo)

--- a/gui_columns.py
+++ b/gui_columns.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+The three workflow-column components.
+
+Extracted from the FlasherFrame god-class: the BalenaEtcher-style
+Firmware → Handset → Flash columns that make up the main window body.
+
+Each column is a ``wx.Panel`` subclass that builds its widgets and wires them to
+frame-level handlers (``on_download`` / ``on_flash`` / ``_refresh_handset_ports`` …).
+Unlike the title/status bars, these columns are the app's core interaction
+surface and their widgets are read and written from all over the frame (the
+port-poll loop, probe threads, workflow gating, the flash/download workers).
+Rather than churn those ~100 call sites, each component assigns its widgets back
+onto the frame as attributes (e.g. ``frame.radio_combo``) exactly as the old
+builder methods did — the construction moves out, the wiring stays identical.
+
+The heading factory (``frame._column_heading``) stays on the frame because the
+log and instructions panels use it too; the columns call it as a collaborator.
+
+The ``wx`` import is guarded so this module and the pure ``radio_display_name``
+helper stay importable in a headless / pyserial-free test environment; the
+column classes are only defined when wx is present.
+"""
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+
+def radio_display_name(name, manufacturer):
+    """Full radio label without double-stamping the manufacturer.
+
+    If the model name already starts with the manufacturer (e.g.
+    ``"BTECH BF-F8HP Pro"``), use it as-is; otherwise prefix the manufacturer
+    (``"Baofeng" + "UV-25 Plus"`` → ``"Baofeng UV-25 Plus"``). Shared by the
+    firmware dropdown and the frame's per-radio info panel so the rule lives in
+    exactly one place.
+    """
+    return name if name.startswith(manufacturer) else f"{manufacturer} {name}".strip()
+
+
+if wx is not None:
+
+    class FirmwareColumn(wx.Panel):
+        """Column 1: radio picker, Download, and firmware path + Browse."""
+
+        def __init__(self, parent, frame):
+            super().__init__(parent)
+            self._frame = frame
+            self._build()
+
+        def _build(self):
+            frame = self._frame
+            from i18n import t
+
+            self.SetMinSize(wx.Size(240, -1))
+            sizer = wx.BoxSizer(wx.VERTICAL)
+            sizer.Add(frame._column_heading(self, "column.firmware"), 0,
+                      wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
+
+            # First entry is a placeholder so the user has to actively pick a
+            # radio (instead of getting whichever radio happened to be in
+            # radios.json[0]). _get_selected_radio() treats index 0 as "no radio
+            # selected" (returns None).
+            frame.RADIO_PLACEHOLDER = t("radio.placeholder")
+            radio_names = [frame.RADIO_PLACEHOLDER] + [
+                radio_display_name(r["name"], r["manufacturer"])
+                for r in frame.radios
+            ]
+            self.radio_combo = wx.ComboBox(self, choices=radio_names,
+                                           style=wx.CB_DROPDOWN | wx.CB_READONLY)
+            self.radio_combo.SetSelection(0)
+            self.radio_combo.Bind(wx.EVT_COMBOBOX, frame.on_radio_changed)
+
+            # On GTK with CB_READONLY, clicking the text portion does nothing —
+            # only the arrow drops down. Bind LEFT_DOWN so a click anywhere on
+            # the combo opens the list.
+            def _open_combo(event):
+                try:
+                    self.radio_combo.Popup()
+                except Exception:
+                    pass
+                event.Skip()
+            self.radio_combo.Bind(wx.EVT_LEFT_DOWN, _open_combo)
+            sizer.Add(self.radio_combo, 0,
+                      wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+            self.download_btn = wx.Button(self, label=t("button.download_latest"))
+            self.download_btn.Bind(wx.EVT_BUTTON, frame.on_download)
+            # download_btn's label is set dynamically by _update_radio_info
+            # (Download Latest / Download v… / No Direct URL), so it isn't
+            # tracked in _i18n_widgets — retranslate_ui re-invokes it.
+            sizer.Add(self.download_btn, 0,
+                      wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+            file_row = wx.BoxSizer(wx.HORIZONTAL)
+            self.file_path = wx.TextCtrl(self)
+            file_row.Add(self.file_path, 1, wx.EXPAND | wx.RIGHT, 4)
+            self.browse_btn = wx.Button(self, label=t("button.browse"))
+            frame._tr_label(self.browse_btn, "button.browse")
+            self.browse_btn.Bind(wx.EVT_BUTTON, frame.on_browse)
+            file_row.Add(self.browse_btn, 0)
+            sizer.Add(file_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+            sizer.AddStretchSpacer(1)
+            self.SetSizer(sizer)
+            frame._rtl_targets.append(self)
+
+            # Expose widgets on the frame (unchanged call sites elsewhere).
+            frame.radio_combo = self.radio_combo
+            frame.download_btn = self.download_btn
+            frame.file_path = self.file_path
+            frame.browse_btn = self.browse_btn
+
+    class HandsetColumn(wx.Panel):
+        """Column 2: multi-select list of detected serial ports + selection helpers."""
+
+        def __init__(self, parent, frame):
+            super().__init__(parent)
+            self._frame = frame
+            self._build()
+
+        def _build(self):
+            frame = self._frame
+            from i18n import t
+
+            self.SetMinSize(wx.Size(280, -1))
+            sizer = wx.BoxSizer(wx.VERTICAL)
+            sizer.Add(frame._column_heading(self, "column.handset"), 0,
+                      wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
+
+            # Multi-select list of detected serial ports / cables. Each row has
+            # a checkbox; FTDI/PC03 cables auto-check on detection. Status column
+            # shows probe results and per-port flash progress.
+            self.handset_list = wx.ListCtrl(self, style=wx.LC_REPORT)
+            checkboxes_supported = False
+            try:
+                self.handset_list.EnableCheckBoxes(True)
+                checkboxes_supported = True
+            except Exception:
+                checkboxes_supported = False
+            # Publish to the frame before _apply_handset_columns (which reads
+            # frame.handset_list) runs.
+            frame.handset_list = self.handset_list
+            frame._handset_checkboxes_supported = checkboxes_supported
+            frame._apply_handset_columns()
+            sizer.Add(self.handset_list, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
+
+            if checkboxes_supported:
+                self.handset_list.Bind(wx.EVT_LIST_ITEM_CHECKED,
+                                       frame._on_handset_check_changed)
+                self.handset_list.Bind(wx.EVT_LIST_ITEM_UNCHECKED,
+                                       frame._on_handset_check_changed)
+            else:
+                self.handset_list.Bind(wx.EVT_LIST_ITEM_SELECTED,
+                                       frame._on_handset_check_changed)
+                self.handset_list.Bind(wx.EVT_LIST_ITEM_DESELECTED,
+                                       frame._on_handset_check_changed)
+
+            # Selection summary + selection helpers. _refresh_handset_summary()
+            # owns the rendering via the i18n "handset.summary" template.
+            self.handset_summary = wx.StaticText(
+                self, label=t("handset.summary").format(selected=0, total=0))
+            sizer.Add(self.handset_summary, 0, wx.LEFT | wx.RIGHT | wx.TOP, 6)
+
+            btn_row = wx.BoxSizer(wx.HORIZONTAL)
+            self.refresh_btn = wx.Button(self, label=t("button.refresh_probe"))
+            frame._tr_label(self.refresh_btn, "button.refresh_probe")
+            frame._tr_tooltip(self.refresh_btn, "tooltip.refresh")
+            self.refresh_btn.Bind(
+                wx.EVT_BUTTON, lambda e: frame._refresh_handset_ports(probe=True))
+            btn_row.Add(self.refresh_btn, 1, wx.RIGHT, 4)
+
+            self.select_all_btn = wx.Button(self, label=t("button.select_all"))
+            frame._tr_label(self.select_all_btn, "button.select_all")
+            frame._tr_tooltip(self.select_all_btn, "tooltip.select_all")
+            self.select_all_btn.Bind(
+                wx.EVT_BUTTON, lambda e: frame._set_all_handsets_checked(True))
+            btn_row.Add(self.select_all_btn, 0, wx.RIGHT, 4)
+
+            self.select_none_btn = wx.Button(self, label=t("button.select_none"))
+            frame._tr_label(self.select_none_btn, "button.select_none")
+            frame._tr_tooltip(self.select_none_btn, "tooltip.select_none")
+            self.select_none_btn.Bind(
+                wx.EVT_BUTTON, lambda e: frame._set_all_handsets_checked(False))
+            btn_row.Add(self.select_none_btn, 0)
+            sizer.Add(btn_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+            self.SetSizer(sizer)
+            frame._rtl_targets.append(self)
+            frame._rtl_targets.append(self.handset_list)
+
+            # Expose remaining widgets on the frame (handset_list already set).
+            frame.handset_summary = self.handset_summary
+            frame.refresh_btn = self.refresh_btn
+            frame.select_all_btn = self.select_all_btn
+            frame.select_none_btn = self.select_none_btn
+
+    class FlashColumn(wx.Panel):
+        """Column 3: Flash button, progress gauge, Dry Run / Diagnostics."""
+
+        def __init__(self, parent, frame):
+            super().__init__(parent)
+            self._frame = frame
+            self._build()
+
+        def _build(self):
+            frame = self._frame
+            from i18n import t
+
+            self.SetMinSize(wx.Size(220, -1))
+            sizer = wx.BoxSizer(wx.VERTICAL)
+            sizer.Add(frame._column_heading(self, "column.flash"), 0,
+                      wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
+
+            self.flash_btn = wx.Button(self, label=t("button.flash_firmware"))
+            frame._tr_label(self.flash_btn, "button.flash_firmware")
+            flash_font = wx.Font(12, wx.FONTFAMILY_DEFAULT,
+                                 wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+            self.flash_btn.SetFont(flash_font)
+            self.flash_btn.Bind(wx.EVT_BUTTON, frame.on_flash)
+            sizer.Add(self.flash_btn, 0,
+                      wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+            self.progress = wx.Gauge(self, range=100)
+            sizer.Add(self.progress, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
+
+            sizer.AddSpacer(4)
+
+            sec_row = wx.BoxSizer(wx.HORIZONTAL)
+            self.dryrun_btn = wx.Button(self, label=t("button.dry_run"))
+            frame._tr_label(self.dryrun_btn, "button.dry_run")
+            self.dryrun_btn.Bind(wx.EVT_BUTTON, frame.on_dry_run)
+            sec_row.Add(self.dryrun_btn, 1, wx.RIGHT, 4)
+            self.diag_btn = wx.Button(self, label=t("button.diagnostics"))
+            frame._tr_label(self.diag_btn, "button.diagnostics")
+            self.diag_btn.Bind(wx.EVT_BUTTON, frame.on_diag)
+            sec_row.Add(self.diag_btn, 1)
+            sizer.Add(sec_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
+
+            sizer.AddStretchSpacer(1)
+            self.SetSizer(sizer)
+            frame._rtl_targets.append(self)
+
+            # Expose widgets on the frame (unchanged call sites elsewhere).
+            frame.flash_btn = self.flash_btn
+            frame.progress = self.progress
+            frame.dryrun_btn = self.dryrun_btn
+            frame.diag_btn = self.diag_btn
+
+else:  # pragma: no cover - exercised only in wx-less test environments
+    FirmwareColumn = None
+    HandsetColumn = None
+    FlashColumn = None

--- a/gui_main.py
+++ b/gui_main.py
@@ -36,6 +36,9 @@ from gui_workflow import (
 )
 from gui_titlebar import TitleBar
 from gui_statusbar import StatusBar, theme_toggle_glyph
+from gui_columns import (
+    FirmwareColumn, HandsetColumn, FlashColumn, radio_display_name,
+)
 
 VERSION = "26.07.0"
 
@@ -116,9 +119,9 @@ class FlasherFrame(wx.Frame):
         self.manifest = None
         self.radios = dl.load_radios()
 
-        col_firmware = self._build_firmware_column(panel)
-        col_handset = self._build_handset_column(panel)
-        col_flash = self._build_flash_column(panel)
+        col_firmware = FirmwareColumn(panel, self)
+        col_handset = HandsetColumn(panel, self)
+        col_flash = FlashColumn(panel, self)
 
         # Bumped one size larger from previous 20pt to give more visual weight.
         arrow_font = wx.Font(28, wx.FONTFAMILY_DEFAULT,
@@ -541,153 +544,6 @@ class FlasherFrame(wx.Frame):
             self._column_headings = []
         self._column_headings.append(h)
         return h
-
-    def _build_firmware_column(self, parent):
-        # Borderless: a wx.Panel + a heading StaticText, no StaticBox.
-        col = wx.Panel(parent)
-        col.SetMinSize(wx.Size(240, -1))
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(self._column_heading(col, "column.firmware"), 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
-
-        # First entry is a placeholder so the user has to actively pick a
-        # radio (instead of getting whichever radio happened to be in
-        # radios.json[0] by default). _get_selected_radio() treats index 0 as
-        # "no radio selected" (returns None).
-        self.RADIO_PLACEHOLDER = t("radio.placeholder")
-        radio_names = [self.RADIO_PLACEHOLDER] + [
-            r['name'] if r['name'].startswith(r['manufacturer'])
-            else f"{r['manufacturer']} {r['name']}"
-            for r in self.radios
-        ]
-        self.radio_combo = wx.ComboBox(col, choices=radio_names,
-                                       style=wx.CB_DROPDOWN | wx.CB_READONLY)
-        self.radio_combo.SetSelection(0)
-        self.radio_combo.Bind(wx.EVT_COMBOBOX, self.on_radio_changed)
-        # On GTK with CB_READONLY, clicking the text portion does nothing —
-        # only the arrow drops down. Bind LEFT_DOWN so a click anywhere on the
-        # combo opens the list.
-        def _open_combo(event):
-            try:
-                self.radio_combo.Popup()
-            except Exception:
-                pass
-            event.Skip()
-        self.radio_combo.Bind(wx.EVT_LEFT_DOWN, _open_combo)
-        sizer.Add(self.radio_combo, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
-
-        self.download_btn = wx.Button(col, label=t("button.download_latest"))
-        self.download_btn.Bind(wx.EVT_BUTTON, self.on_download)
-        # Note: download_btn's label is set dynamically by _update_radio_info
-        # (Download Latest / Download v… / No Direct URL) and so isn't tracked
-        # in _i18n_widgets — retranslate_ui re-invokes _update_radio_info.
-        sizer.Add(self.download_btn, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
-
-        file_row = wx.BoxSizer(wx.HORIZONTAL)
-        self.file_path = wx.TextCtrl(col)
-        file_row.Add(self.file_path, 1, wx.EXPAND | wx.RIGHT, 4)
-        self.browse_btn = wx.Button(col, label=t("button.browse"))
-        self._tr_label(self.browse_btn, "button.browse")
-        self.browse_btn.Bind(wx.EVT_BUTTON, self.on_browse)
-        file_row.Add(self.browse_btn, 0)
-        sizer.Add(file_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
-
-        sizer.AddStretchSpacer(1)
-        col.SetSizer(sizer)
-        self._rtl_targets.append(col)
-        return col
-
-    def _build_handset_column(self, parent):
-        col = wx.Panel(parent)
-        col.SetMinSize(wx.Size(280, -1))
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(self._column_heading(col, "column.handset"), 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
-
-        # Multi-select list of detected serial ports / cables. Each row has
-        # a checkbox; FTDI/PC03 cables auto-check on detection. Status column
-        # shows probe results (Ready / No response) and per-port flash progress.
-        self.handset_list = wx.ListCtrl(col, style=wx.LC_REPORT)
-        self._handset_checkboxes_supported = False
-        try:
-            self.handset_list.EnableCheckBoxes(True)
-            self._handset_checkboxes_supported = True
-        except Exception:
-            self._handset_checkboxes_supported = False
-        self._apply_handset_columns()
-        sizer.Add(self.handset_list, 1, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
-
-        if self._handset_checkboxes_supported:
-            self.handset_list.Bind(wx.EVT_LIST_ITEM_CHECKED, self._on_handset_check_changed)
-            self.handset_list.Bind(wx.EVT_LIST_ITEM_UNCHECKED, self._on_handset_check_changed)
-        else:
-            self.handset_list.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_handset_check_changed)
-            self.handset_list.Bind(wx.EVT_LIST_ITEM_DESELECTED, self._on_handset_check_changed)
-
-        # Selection summary + selection helpers. Summary text is computed via
-        # the i18n "handset.summary" template; _refresh_handset_summary() owns
-        # the rendering.
-        self.handset_summary = wx.StaticText(
-            col, label=t("handset.summary").format(selected=0, total=0))
-        sizer.Add(self.handset_summary, 0, wx.LEFT | wx.RIGHT | wx.TOP, 6)
-
-        btn_row = wx.BoxSizer(wx.HORIZONTAL)
-        self.refresh_btn = wx.Button(col, label=t("button.refresh_probe"))
-        self._tr_label(self.refresh_btn, "button.refresh_probe")
-        self._tr_tooltip(self.refresh_btn, "tooltip.refresh")
-        self.refresh_btn.Bind(wx.EVT_BUTTON, lambda e: self._refresh_handset_ports(probe=True))
-        btn_row.Add(self.refresh_btn, 1, wx.RIGHT, 4)
-
-        self.select_all_btn = wx.Button(col, label=t("button.select_all"))
-        self._tr_label(self.select_all_btn, "button.select_all")
-        self._tr_tooltip(self.select_all_btn, "tooltip.select_all")
-        self.select_all_btn.Bind(wx.EVT_BUTTON, lambda e: self._set_all_handsets_checked(True))
-        btn_row.Add(self.select_all_btn, 0, wx.RIGHT, 4)
-
-        self.select_none_btn = wx.Button(col, label=t("button.select_none"))
-        self._tr_label(self.select_none_btn, "button.select_none")
-        self._tr_tooltip(self.select_none_btn, "tooltip.select_none")
-        self.select_none_btn.Bind(wx.EVT_BUTTON, lambda e: self._set_all_handsets_checked(False))
-        btn_row.Add(self.select_none_btn, 0)
-        sizer.Add(btn_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
-
-        col.SetSizer(sizer)
-        self._rtl_targets.append(col)
-        self._rtl_targets.append(self.handset_list)
-        return col
-
-    def _build_flash_column(self, parent):
-        col = wx.Panel(parent)
-        col.SetMinSize(wx.Size(220, -1))
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(self._column_heading(col, "column.flash"), 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 6)
-
-        self.flash_btn = wx.Button(col, label=t("button.flash_firmware"))
-        self._tr_label(self.flash_btn, "button.flash_firmware")
-        flash_font = wx.Font(12, wx.FONTFAMILY_DEFAULT,
-                             wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
-        self.flash_btn.SetFont(flash_font)
-        self.flash_btn.Bind(wx.EVT_BUTTON, self.on_flash)
-        sizer.Add(self.flash_btn, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
-
-        self.progress = wx.Gauge(col, range=100)
-        sizer.Add(self.progress, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
-
-        sizer.AddSpacer(4)
-
-        sec_row = wx.BoxSizer(wx.HORIZONTAL)
-        self.dryrun_btn = wx.Button(col, label=t("button.dry_run"))
-        self._tr_label(self.dryrun_btn, "button.dry_run")
-        self.dryrun_btn.Bind(wx.EVT_BUTTON, self.on_dry_run)
-        sec_row.Add(self.dryrun_btn, 1, wx.RIGHT, 4)
-        self.diag_btn = wx.Button(col, label=t("button.diagnostics"))
-        self._tr_label(self.diag_btn, "button.diagnostics")
-        self.diag_btn.Bind(wx.EVT_BUTTON, self.on_diag)
-        sec_row.Add(self.diag_btn, 1)
-        sizer.Add(sec_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 6)
-
-        sizer.AddStretchSpacer(1)
-        col.SetSizer(sizer)
-        self._rtl_targets.append(col)
-        return col
 
     def _toggle_theme(self):
         """Switch between mocha (dark) and latte (light), re-render everything."""
@@ -1148,11 +1004,10 @@ class FlasherFrame(wx.Frame):
         keys = radio.get("bootloader_keys")
         connector = radio.get("connector")
         tested = radio.get("tested")
-        # Same dedup logic as the dropdown: skip the manufacturer prefix when
-        # the name already starts with it (e.g. "BTECH BF-F8HP Pro").
-        manufacturer = radio.get("manufacturer", "")
-        name = radio.get("name", "")
-        full_name = name if name.startswith(manufacturer) else f"{manufacturer} {name}".strip()
+        # Same dedup rule as the dropdown (shared helper), so the manufacturer
+        # isn't double-stamped when the name already starts with it.
+        full_name = radio_display_name(radio.get("name", ""),
+                                       radio.get("manufacturer", ""))
         bits.append(t("info.radio_label").format(name=full_name))
         if keys:
             bits.append(t("info.bootloader_keys").format(

--- a/tests.py
+++ b/tests.py
@@ -654,8 +654,8 @@ class TestRadioNameDedup(unittest.TestCase):
     def _full_name(manufacturer, name):
         # Delegates to the real production helper (gui_columns.radio_display_name),
         # shared by the firmware dropdown and the frame's per-radio info panel.
-        from gui_columns import radio_display_name
-        return radio_display_name(name, manufacturer)
+        import gui_columns
+        return gui_columns.radio_display_name(name, manufacturer)
 
     def test_name_already_starts_with_manufacturer(self):
         self.assertEqual(self._full_name("BTECH", "BTECH BF-F8HP Pro"),

--- a/tests.py
+++ b/tests.py
@@ -652,8 +652,10 @@ class TestRadioNameDedup(unittest.TestCase):
 
     @staticmethod
     def _full_name(manufacturer, name):
-        # Same one-liner used in both call sites.
-        return name if name.startswith(manufacturer) else f"{manufacturer} {name}".strip()
+        # Delegates to the real production helper (gui_columns.radio_display_name),
+        # shared by the firmware dropdown and the frame's per-radio info panel.
+        from gui_columns import radio_display_name
+        return radio_display_name(name, manufacturer)
 
     def test_name_already_starts_with_manufacturer(self):
         self.assertEqual(self._full_name("BTECH", "BTECH BF-F8HP Pro"),
@@ -1461,6 +1463,34 @@ class TestStatusBarModule(unittest.TestCase):
         # Importable without wxPython; StatusBar is a class in CI, None here.
         self.assertTrue(hasattr(self.s, "StatusBar"))
         self.assertTrue(self.s.RELEASES_URL.startswith("https://"))
+
+
+class TestColumnsModule(unittest.TestCase):
+    """Pure radio-name helper + import contract (widgets tested via wx in CI)."""
+
+    def setUp(self):
+        import gui_columns
+        self.c = gui_columns
+
+    def test_radio_display_name_no_double_stamp(self):
+        # Name already starts with manufacturer -> used as-is.
+        self.assertEqual(
+            self.c.radio_display_name("BTECH BF-F8HP Pro", "BTECH"),
+            "BTECH BF-F8HP Pro")
+
+    def test_radio_display_name_prefixes_manufacturer(self):
+        self.assertEqual(
+            self.c.radio_display_name("UV-25 Plus", "Baofeng"),
+            "Baofeng UV-25 Plus")
+
+    def test_radio_display_name_strips(self):
+        # Empty manufacturer must not leave a leading space.
+        self.assertEqual(self.c.radio_display_name("RT-490", ""), "RT-490")
+
+    def test_module_imports_and_exposes_columns(self):
+        # Importable without wxPython; the column classes are defined in CI.
+        for name in ("FirmwareColumn", "HandsetColumn", "FlashColumn"):
+            self.assertTrue(hasattr(self.c, name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fourth and final slice of decomposing the `FlasherFrame` god-class (after #15 workflow state, #16 title bar, #17 status bar). This moves the three BalenaEtcher-style workflow columns — **Firmware → Handset → Flash** — out of the frame into `gui_columns.py` as three `wx.Panel` subclasses: `FirmwareColumn`, `HandsetColumn`, `FlashColumn`.

## Approach — construction-only, zero call-site churn

Unlike the title/status bars, these columns are the app's **core interaction surface**: their widgets (the radio combo, the handset `ListCtrl`, the progress gauge, the flash/dry-run/diag buttons, …) are read and written from ~100 sites across the frame — the port-poll loop, probe threads, workflow gating, the flash/download worker threads. Rewiring all of those would be large and risky, and CI can't exercise the widget behavior headlessly.

So each component **builds its widgets and assigns them back onto the frame as attributes**, exactly as the old builder methods did (`frame.radio_combo = …`, `frame.handset_list = …`). The construction moves out; every existing reference stays valid and unchanged. The shared heading factory (`_column_heading`) stays on the frame because the log and instructions panels use it too. The handset column publishes `frame.handset_list` before calling `frame._apply_handset_columns()`, preserving the original construction order.

## Bonus dedup

Extracts **`radio_display_name(name, manufacturer)`** — the "don't double-stamp the manufacturer when the model name already starts with it" rule (e.g. `BTECH BF-F8HP Pro`, not `BTECH BTECH BF-F8HP Pro`) — into a pure helper. It was copy-pasted in the firmware dropdown and `_format_radio_info`; both now call the one helper, and the existing `TestRadioNameDedup` suite is repointed from its private copy to the real production function.

## Behavior

Identical — same widgets, same handlers, same theming / retranslation / RTL wiring, same construction order.

`gui_columns` guards its `wx` import so the module and the pure helper load headlessly (the column classes are `None` there); the real widgets are exercised in CI via `gui_main`'s import path.

Verified by **4 new unit tests** (146 → 150): the display-name helper (no-double-stamp / prefix / strip) and the module import contract. `python3 tests.py` → 150 passed, 8 skipped (GUI tests needing wxPython, which run in CI).

## Result

`gui_main.py` drops ~150 lines to **~2,020** — down from ~2,305 at the start of the decomposition. The four extracted slices now live in focused modules:

- ✅ workflow state machine → `gui_workflow` (#15)
- ✅ custom title bar → `TitleBar` + `WindowDragger` (#16)
- ✅ status bar → `StatusBar` (#17)
- ✅ **the three workflow columns → `gui_columns` (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_