### PR TITLE
Extract handset-column behavior into HandsetController

### DIFF
--- a/gui_handset.py
+++ b/gui_handset.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Handset-column behavior: port discovery, probing, polling, and selection.
+
+This is the *controller* half of the handset column — the runtime logic that
+was the deepest remaining coupling in FlasherFrame. It owns the model of
+detected ports and drives the wx ListCtrl: enumerating USB serial ports,
+a background thread that watches for plug/unplug, a probe thread that sends the
+protocol-appropriate handshake to each port, and the per-row status / progress /
+checkbox updates plus the selection summary.
+
+``HandsetController`` collaborates with the owning frame for everything only the
+frame can provide: the ListCtrl / summary / refresh widgets, the ``_busy`` and
+``_closing`` flags, protocol dispatch (``_driver_for`` / ``_get_selected_radio``),
+the dialout-permission hint, and the workflow feedback it triggers on selection
+changes (``_compute_hint_state`` / ``_set_hint`` / ``_update_workflow_gating``).
+The frame exposes thin delegators (``_set_handset_status`` etc.) so the flash
+workers and gui_columns keep calling the same names.
+
+``enumerate_serial_ports`` and ``poll_signature`` are pure (a ``comports``
+callable is injectable) so they're unit-tested without pyserial or a display;
+the threaded/widget parts are verified against real hardware.
+"""
+
+import os
+import time
+import threading
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+import i18n
+from i18n import t
+from gui_ports import KNOWN_CABLES, FTDI_VID_PID
+
+# Handset-list status values are i18n keys; the rendering layer calls t() on
+# them when writing a status cell. Comparisons use these symbolic constants;
+# only the on-screen text runs through the translation table. (Moved here from
+# gui_main so the controller and the flash workers share one definition.)
+STATUS_UNKNOWN = "status.unknown"
+STATUS_PROBING = "status.probing"
+STATUS_READY = "status.ready"
+STATUS_NO_RESP = "status.no_response"
+STATUS_FLASHING = "status.flashing"
+STATUS_DONE = "status.done"
+STATUS_FAILED = "status.failed"
+STATUS_SKIPPED = "status.skipped"
+
+
+def enumerate_serial_ports(comports=None):
+    """Return dicts describing currently visible USB serial ports.
+
+    Non-USB serial ports (motherboard 16550 ``/dev/ttyS*``) are filtered out —
+    all known KDH programming cables are USB-attached, and showing 30+ unused
+    UARTs would also balloon probe time (~1.5s per port).
+
+    ``comports`` is injectable for testing; by default it uses
+    ``serial.tools.list_ports.comports``.
+    """
+    if comports is None:
+        import serial.tools.list_ports
+        comports = serial.tools.list_ports.comports
+    out = []
+    for p in comports():
+        if not (p.vid and p.pid):
+            continue  # skip non-USB ports
+        vid_pid = (p.vid, p.pid)
+        cable = KNOWN_CABLES.get(vid_pid, p.description or "")
+        out.append({
+            "device": p.device,
+            "cable": cable,
+            "vid_pid": vid_pid,
+            "status": STATUS_UNKNOWN,
+            "progress": "",
+            "is_pc03": vid_pid == FTDI_VID_PID,
+        })
+    return out
+
+
+def poll_signature(ports):
+    """Stable signature of the visible port set, for plug/unplug change detection."""
+    return tuple(sorted(p["device"] for p in ports))
+
+
+class HandsetController:
+    """Owns the handset port model and drives the handset ListCtrl."""
+
+    def __init__(self, frame):
+        self.frame = frame
+        self.ports = []              # list of dicts: device, cable, vid_pid, status, progress
+        self._probing = False        # True while the probe thread is walking ports
+        self._poll_signature = None  # last visible-port signature (change detection)
+
+    # -- column headers --------------------------------------------------- #
+    def apply_columns(self):
+        """Insert / rebuild the handset table column headers in the active language.
+
+        Column header alignment doesn't auto-mirror under SetLayoutDirection, so
+        we re-create the columns with the right format whenever the language
+        changes.
+        """
+        frame = self.frame
+        if not hasattr(frame, "handset_list"):
+            return
+        fmt = (wx.LIST_FORMAT_RIGHT if i18n.is_rtl() else wx.LIST_FORMAT_LEFT)
+        # Stash existing widths so we don't lose user resize state.
+        had_columns = frame.handset_list.GetColumnCount() > 0
+        widths = ([frame.handset_list.GetColumnWidth(i) for i in range(4)]
+                  if had_columns else [110, 140, 110, 50])
+        frame.handset_list.ClearAll()
+        for idx, (key, width) in enumerate(zip(
+                ("handset.col_port", "handset.col_cable",
+                 "handset.col_status", "handset.col_percent"),
+                widths)):
+            frame.handset_list.InsertColumn(idx, t(key), width=width, format=fmt)
+
+    # -- refresh / probe / poll ------------------------------------------ #
+    def refresh_ports(self, probe=False, preserve_checks=False):
+        """Re-enumerate ports and rebuild the handset list.
+
+        If probe=True, sends a handshake to each port in a background thread and
+        updates Status. PC03 cables are auto-checked unless preserve_checks is
+        True (used by the polling loop so we don't fight the user).
+        """
+        frame = self.frame
+        if frame._busy or self._probing:
+            # Don't reshape the list while flashing, or while a probe thread is
+            # posting status updates keyed by row index — a rebuild here would
+            # invalidate those indices and land results on the wrong rows.
+            return
+
+        previously_checked = set()
+        if preserve_checks:
+            for i in range(frame.handset_list.GetItemCount()):
+                if self.is_checked(i):
+                    previously_checked.add(self.ports[i]["device"])
+
+        new_ports = enumerate_serial_ports()
+        frame.handset_list.DeleteAllItems()
+        self.ports = new_ports
+
+        for entry in new_ports:
+            # Show only the device basename (e.g. "ttyUSB0") — the full path is
+            # kept in entry["device"] for serial.Serial calls.
+            display_port = os.path.basename(entry["device"]) or entry["device"]
+            idx = frame.handset_list.InsertItem(
+                frame.handset_list.GetItemCount(), display_port)
+            frame.handset_list.SetItem(idx, 1, entry["cable"])
+            frame.handset_list.SetItem(idx, 2, t(entry["status"]))
+            frame.handset_list.SetItem(idx, 3, entry["progress"])
+
+            should_check = (
+                entry["device"] in previously_checked
+                or (not preserve_checks and entry["is_pc03"])
+            )
+            if should_check:
+                self.set_check(idx, True)
+
+        self.refresh_summary()
+
+        if probe and new_ports:
+            frame.refresh_btn.Disable()
+            self._probing = True
+            threading.Thread(target=self._probe_thread, daemon=True).start()
+
+    def _probe_thread(self):
+        """Send the protocol-appropriate handshake to every listed port; update
+        Status as we go. The handshake is dispatched on the selected radio's
+        protocol — KDH ("BOOTLOADER" handshake) or BTF (cmd 0x42 probe).
+
+        If the very first probe hits PermissionError (Linux dialout), surface the
+        hint once and abort instead of marking every port "No response".
+        """
+        frame = self.frame
+        driver = frame._driver_for(frame._get_selected_radio())
+        permission_blocked = False
+        try:
+            for idx, entry in enumerate(list(self.ports)):
+                wx.CallAfter(self.set_status, idx, STATUS_PROBING)
+                try:
+                    ready = driver.probe_port(entry["device"], timeout=1.5)
+                except PermissionError:
+                    permission_blocked = True
+                    wx.CallAfter(frame._log_dialout_hint, entry["device"])
+                    # Mark this port and all remaining ones as Unknown rather
+                    # than No response — they may well be radios.
+                    for remaining_idx in range(idx, len(self.ports)):
+                        wx.CallAfter(self.set_status, remaining_idx, STATUS_UNKNOWN)
+                    break
+                except Exception:
+                    # A non-permission failure (port vanished, busy, I/O error)
+                    # still needs a terminal status, otherwise the row is left
+                    # showing "Probing…" forever.
+                    wx.CallAfter(self.set_status, idx, STATUS_NO_RESP)
+                else:
+                    new_status = STATUS_READY if ready else STATUS_NO_RESP
+                    wx.CallAfter(self.set_status, idx, new_status)
+                    if ready:
+                        wx.CallAfter(self.set_check, idx, True)
+        finally:
+            # Always clear the in-flight flag, even on an unexpected error, so
+            # the port-poll loop isn't blocked from refreshing forever.
+            self._probing = False
+        wx.CallAfter(frame.refresh_btn.Enable)
+        if not permission_blocked:
+            wx.CallAfter(lambda: frame._set_hint(frame._compute_hint_state()))
+
+    def port_poll_loop(self):
+        """Background thread: detect plug/unplug events and trigger refresh.
+
+        Polls every 2 seconds; when the set of visible ports changes (and we
+        aren't busy), refresh the list while preserving user-made checkbox state.
+        """
+        frame = self.frame
+        while not frame._closing:
+            time.sleep(2.0)
+            if frame._closing:
+                break
+            try:
+                ports = enumerate_serial_ports()
+                signature = poll_signature(ports)
+                if signature != self._poll_signature:
+                    self._poll_signature = signature
+                    if not frame._busy:
+                        wx.CallAfter(self.refresh_ports, False, True)
+            except Exception:
+                pass
+
+    # -- row / selection helpers ----------------------------------------- #
+    def set_status(self, idx, status):
+        frame = self.frame
+        if 0 <= idx < len(self.ports):
+            self.ports[idx]["status"] = status
+            try:
+                frame.handset_list.SetItem(idx, 2, t(status))
+            except Exception:
+                pass
+            self.refresh_summary()
+
+    def set_progress(self, idx, text):
+        frame = self.frame
+        if 0 <= idx < len(self.ports):
+            self.ports[idx]["progress"] = text
+            try:
+                frame.handset_list.SetItem(idx, 3, text)
+            except Exception:
+                pass
+
+    def set_check(self, idx, checked):
+        frame = self.frame
+        if not (0 <= idx < frame.handset_list.GetItemCount()):
+            return
+        if frame._handset_checkboxes_supported:
+            frame.handset_list.CheckItem(idx, checked)
+        else:
+            frame.handset_list.Select(idx, on=1 if checked else 0)
+        self.refresh_summary()
+
+    def is_checked(self, idx):
+        frame = self.frame
+        if not (0 <= idx < frame.handset_list.GetItemCount()):
+            return False
+        if frame._handset_checkboxes_supported:
+            return frame.handset_list.IsItemChecked(idx)
+        return frame.handset_list.IsSelected(idx)
+
+    def set_all_checked(self, checked):
+        frame = self.frame
+        for idx in range(frame.handset_list.GetItemCount()):
+            self.set_check(idx, checked)
+
+    def on_check_changed(self, event):
+        frame = self.frame
+        self.refresh_summary()
+        frame._terminal_state = None
+        frame._set_hint(frame._compute_hint_state())
+        frame._update_workflow_gating()
+        if event:
+            event.Skip()
+
+    def refresh_summary(self):
+        frame = self.frame
+        total = frame.handset_list.GetItemCount()
+        sel = sum(1 for i in range(total) if self.is_checked(i))
+        frame.handset_summary.SetLabel(
+            t("handset.summary").format(selected=sel, total=total))
+
+    def selected_indices(self):
+        frame = self.frame
+        return [i for i in range(frame.handset_list.GetItemCount())
+                if self.is_checked(i)]
+
+    def selected_devices(self):
+        return [self.ports[i]["device"] for i in self.selected_indices()]

--- a/gui_handset.py
+++ b/gui_handset.py
@@ -32,7 +32,6 @@ except ImportError:
     wx = None
 
 import i18n
-from i18n import t
 from gui_ports import KNOWN_CABLES, FTDI_VID_PID
 
 # Handset-list status values are i18n keys; the rendering layer calls t() on
@@ -114,7 +113,7 @@ class HandsetController:
                 ("handset.col_port", "handset.col_cable",
                  "handset.col_status", "handset.col_percent"),
                 widths)):
-            frame.handset_list.InsertColumn(idx, t(key), width=width, format=fmt)
+            frame.handset_list.InsertColumn(idx, i18n.t(key), width=width, format=fmt)
 
     # -- refresh / probe / poll ------------------------------------------ #
     def refresh_ports(self, probe=False, preserve_checks=False):
@@ -148,7 +147,7 @@ class HandsetController:
             idx = frame.handset_list.InsertItem(
                 frame.handset_list.GetItemCount(), display_port)
             frame.handset_list.SetItem(idx, 1, entry["cable"])
-            frame.handset_list.SetItem(idx, 2, t(entry["status"]))
+            frame.handset_list.SetItem(idx, 2, i18n.t(entry["status"]))
             frame.handset_list.SetItem(idx, 3, entry["progress"])
 
             should_check = (
@@ -226,6 +225,9 @@ class HandsetController:
                     if not frame._busy:
                         wx.CallAfter(self.refresh_ports, False, True)
             except Exception:
+                # Enumeration can fail transiently (a port vanishing mid-scan,
+                # a driver hiccup). Swallow it so the poll thread keeps running;
+                # the next tick re-scans.
                 pass
 
     # -- row / selection helpers ----------------------------------------- #
@@ -234,8 +236,11 @@ class HandsetController:
         if 0 <= idx < len(self.ports):
             self.ports[idx]["status"] = status
             try:
-                frame.handset_list.SetItem(idx, 2, t(status))
+                frame.handset_list.SetItem(idx, 2, i18n.t(status))
             except Exception:
+                # SetItem can race with a list rebuild or widget teardown; a
+                # failed status paint is cosmetic and safe to ignore (the model
+                # value is already updated above).
                 pass
             self.refresh_summary()
 
@@ -246,6 +251,8 @@ class HandsetController:
             try:
                 frame.handset_list.SetItem(idx, 3, text)
             except Exception:
+                # As in set_status: a transient SetItem failure during a row
+                # refresh or teardown is non-fatal; the model value is set.
                 pass
 
     def set_check(self, idx, checked):
@@ -285,7 +292,7 @@ class HandsetController:
         total = frame.handset_list.GetItemCount()
         sel = sum(1 for i in range(total) if self.is_checked(i))
         frame.handset_summary.SetLabel(
-            t("handset.summary").format(selected=sel, total=total))
+            i18n.t("handset.summary").format(selected=sel, total=total))
 
     def selected_indices(self):
         frame = self.frame

--- a/gui_main.py
+++ b/gui_main.py
@@ -22,7 +22,6 @@ from i18n import t, t_radio_field
 import updater
 import serial
 
-from gui_ports import list_serial_ports, find_programming_cable, KNOWN_CABLES, FTDI_VID_PID
 from gui_dialogs import (
     show_about_dialog,
     show_test_report_dialog,
@@ -39,23 +38,17 @@ from gui_statusbar import StatusBar, theme_toggle_glyph
 from gui_columns import (
     FirmwareColumn, HandsetColumn, FlashColumn, radio_display_name,
 )
+from gui_handset import (
+    HandsetController,
+    # Flash-worker status values (i18n keys) — comparisons use these symbolic
+    # constants; only the on-screen text runs through t(). The full status
+    # vocabulary lives in gui_handset alongside the controller that emits it.
+    STATUS_FLASHING, STATUS_DONE, STATUS_FAILED, STATUS_SKIPPED,
+)
 
 VERSION = "26.07.0"
 
 FONT_SIZES = [9, 11, 12, 14, 16]
-
-# Handset list status values are i18n keys; the rendering layer calls t() on
-# them whenever a status cell is written. Status comparisons throughout the
-# module continue to use these symbolic constants verbatim — only the on-screen
-# representation runs through the translation table.
-STATUS_UNKNOWN = "status.unknown"
-STATUS_PROBING = "status.probing"
-STATUS_READY = "status.ready"
-STATUS_NO_RESP = "status.no_response"
-STATUS_FLASHING = "status.flashing"
-STATUS_DONE = "status.done"
-STATUS_FAILED = "status.failed"
-STATUS_SKIPPED = "status.skipped"
 
 
 class FlasherFrame(wx.Frame):
@@ -92,11 +85,11 @@ class FlasherFrame(wx.Frame):
         self.current_theme = "mocha"
         self.current_theme_palette = MOCHA_PALETTE
         self._busy = False
-        self._probing = False        # True while _probe_thread is walking ports
         self._closing = False        # set on EVT_CLOSE so bg loops can stop
         self._terminal_state = None  # set to "complete"/"failed" by threads
-        self._handset_ports = []     # list of dicts: device, cable, vid_pid, status, progress
-        self._port_poll_signature = None  # last (device,cable,vid_pid) tuple for change detection
+        # Handset-column behavior (port discovery, probe, poll, selection) lives
+        # in HandsetController; the frame exposes thin delegators below.
+        self.handset = HandsetController(self)
         self._update_url = None       # set by _check_update when an update is detected
 
         # Window icon
@@ -285,7 +278,7 @@ class FlasherFrame(wx.Frame):
         # Background: update check, manifest fetch, port-change polling
         threading.Thread(target=self._check_update, daemon=True).start()
         threading.Thread(target=self._fetch_manifest, daemon=True).start()
-        threading.Thread(target=self._port_poll_loop, daemon=True).start()
+        threading.Thread(target=self.handset.port_poll_loop, daemon=True).start()
 
     # ------------------------------------------------------------------
     # i18n helpers
@@ -312,29 +305,6 @@ class FlasherFrame(wx.Frame):
     def _resolve_direction(self):
         return (wx.Layout_RightToLeft if i18n.is_rtl()
                 else wx.Layout_LeftToRight)
-
-    def _apply_handset_columns(self):
-        """Insert / rebuild the handset table column headers in the active language.
-
-        Column header alignment doesn't auto-mirror under SetLayoutDirection, so
-        we re-create the columns with the right format whenever the language
-        changes.
-        """
-        if not hasattr(self, "handset_list"):
-            return
-        fmt = (wx.LIST_FORMAT_RIGHT if i18n.is_rtl()
-               else wx.LIST_FORMAT_LEFT)
-        # Stash existing widths so we don't lose user resize state.
-        had_columns = self.handset_list.GetColumnCount() > 0
-        widths = ([self.handset_list.GetColumnWidth(i) for i in range(4)]
-                  if had_columns else [110, 140, 110, 50])
-        self.handset_list.ClearAll()
-        for idx, (key, width) in enumerate(zip(
-                ("handset.col_port", "handset.col_cable",
-                 "handset.col_status", "handset.col_percent"),
-                widths)):
-            self.handset_list.InsertColumn(idx, t(key),
-                                           width=width, format=fmt)
 
     def _language_button_label(self):
         """Status-bar text for the language button — native label of the
@@ -569,203 +539,41 @@ class FlasherFrame(wx.Frame):
     # Handset list management (port discovery, probe, checkboxes)
     # ------------------------------------------------------------------
 
-    def _enumerate_serial_ports(self):
-        """Return list of dicts describing currently visible USB serial ports.
+    # --- Handset column: behavior delegated to HandsetController (gui_handset)
+    # These thin wrappers keep the existing call sites (flash workers,
+    # workflow gating, gui_columns, retranslate_ui) unchanged while the logic
+    # lives in the controller.
 
-        We filter out non-USB serial ports (motherboard 16550 /dev/ttyS*) since
-        all known KDH programming cables are USB-attached. Showing 30+ unused
-        UARTs would also balloon probe time (each port takes ~1.5s).
-        """
-        import serial.tools.list_ports
-        out = []
-        for p in serial.tools.list_ports.comports():
-            if not (p.vid and p.pid):
-                continue  # skip non-USB ports
-            vid_pid = (p.vid, p.pid)
-            cable = KNOWN_CABLES.get(vid_pid, p.description or "")
-            out.append({
-                "device": p.device,
-                "cable": cable,
-                "vid_pid": vid_pid,
-                "status": STATUS_UNKNOWN,
-                "progress": "",
-                "is_pc03": vid_pid == FTDI_VID_PID,
-            })
-        return out
+    @property
+    def _handset_ports(self):
+        return self.handset.ports
+
+    def _apply_handset_columns(self):
+        self.handset.apply_columns()
 
     def _refresh_handset_ports(self, probe=False, preserve_checks=False):
-        """Re-enumerate ports and rebuild the handset list.
-
-        If probe=True, sends a CMD_HANDSHAKE to each port in a background thread
-        and updates Status. PC03 cables are auto-checked unless preserve_checks
-        is True (used by the polling loop so we don't fight the user).
-        """
-        if self._busy or self._probing:
-            # Don't reshape the list while flashing, or while a probe thread is
-            # posting status updates keyed by row index — a rebuild here would
-            # invalidate those indices and land results on the wrong rows.
-            return
-
-        previously_checked = set()
-        if preserve_checks:
-            for i in range(self.handset_list.GetItemCount()):
-                if self._is_handset_checked(i):
-                    previously_checked.add(self._handset_ports[i]["device"])
-
-        new_ports = self._enumerate_serial_ports()
-        self.handset_list.DeleteAllItems()
-        self._handset_ports = new_ports
-
-        for entry in new_ports:
-            # Show only the device basename (e.g. "ttyUSB0") — the full path
-            # is kept in entry["device"] for serial.Serial calls.
-            display_port = os.path.basename(entry["device"]) or entry["device"]
-            idx = self.handset_list.InsertItem(
-                self.handset_list.GetItemCount(), display_port)
-            self.handset_list.SetItem(idx, 1, entry["cable"])
-            self.handset_list.SetItem(idx, 2, t(entry["status"]))
-            self.handset_list.SetItem(idx, 3, entry["progress"])
-
-            should_check = (
-                entry["device"] in previously_checked
-                or (not preserve_checks and entry["is_pc03"])
-            )
-            if should_check:
-                self._set_handset_check(idx, True)
-
-        self._refresh_handset_summary()
-
-        if probe and new_ports:
-            self.refresh_btn.Disable()
-            self._probing = True
-            threading.Thread(target=self._probe_thread, daemon=True).start()
-
-    def _probe_thread(self):
-        """Send the protocol-appropriate handshake to every listed port; update
-        Status as we go. The handshake is dispatched on the selected radio's
-        protocol — KDH ("BOOTLOADER" handshake) or BTF (cmd 0x42 probe).
-
-        If the very first probe hits PermissionError (Linux dialout), surface
-        the hint once and abort instead of marking every port "No response".
-        """
-        driver = self._driver_for(self._get_selected_radio())
-        permission_blocked = False
-        try:
-            for idx, entry in enumerate(list(self._handset_ports)):
-                wx.CallAfter(self._set_handset_status, idx, STATUS_PROBING)
-                try:
-                    ready = driver.probe_port(entry["device"], timeout=1.5)
-                except PermissionError:
-                    permission_blocked = True
-                    wx.CallAfter(self._log_dialout_hint, entry["device"])
-                    # Mark this port and all remaining ones as Unknown rather
-                    # than No response — they may well be radios.
-                    for remaining_idx in range(idx, len(self._handset_ports)):
-                        wx.CallAfter(self._set_handset_status,
-                                     remaining_idx, STATUS_UNKNOWN)
-                    break
-                except Exception:
-                    # A non-permission failure (port vanished, busy, I/O error)
-                    # still needs a terminal status, otherwise the row is left
-                    # showing "Probing…" forever.
-                    wx.CallAfter(self._set_handset_status, idx, STATUS_NO_RESP)
-                else:
-                    new_status = STATUS_READY if ready else STATUS_NO_RESP
-                    wx.CallAfter(self._set_handset_status, idx, new_status)
-                    if ready:
-                        wx.CallAfter(self._set_handset_check, idx, True)
-        finally:
-            # Always clear the in-flight flag, even on an unexpected error, so
-            # the port-poll loop isn't blocked from refreshing forever.
-            self._probing = False
-        wx.CallAfter(self.refresh_btn.Enable)
-        if not permission_blocked:
-            wx.CallAfter(lambda: self._set_hint(self._compute_hint_state()))
-
-    def _port_poll_loop(self):
-        """Background thread: detect plug/unplug events and trigger refresh.
-
-        Polls every 2 seconds; when the set of visible ports changes (and we
-        aren't busy), refresh the list while preserving user-made checkbox state.
-        """
-        import time
-        while not self._closing:
-            time.sleep(2.0)
-            if self._closing:
-                break
-            try:
-                ports = self._enumerate_serial_ports()
-                signature = tuple(sorted(p["device"] for p in ports))
-                if signature != self._port_poll_signature:
-                    self._port_poll_signature = signature
-                    if not self._busy:
-                        wx.CallAfter(
-                            self._refresh_handset_ports,
-                            False, True
-                        )
-            except Exception:
-                pass
-
-    # --- Handset list helpers ---
-
-    def _set_handset_status(self, idx, status):
-        if 0 <= idx < len(self._handset_ports):
-            self._handset_ports[idx]["status"] = status
-            try:
-                self.handset_list.SetItem(idx, 2, t(status))
-            except Exception:
-                pass
-            self._refresh_handset_summary()
-
-    def _set_handset_progress(self, idx, text):
-        if 0 <= idx < len(self._handset_ports):
-            self._handset_ports[idx]["progress"] = text
-            try:
-                self.handset_list.SetItem(idx, 3, text)
-            except Exception:
-                pass
-
-    def _set_handset_check(self, idx, checked):
-        if not (0 <= idx < self.handset_list.GetItemCount()):
-            return
-        if self._handset_checkboxes_supported:
-            self.handset_list.CheckItem(idx, checked)
-        else:
-            self.handset_list.Select(idx, on=1 if checked else 0)
-        self._refresh_handset_summary()
-
-    def _is_handset_checked(self, idx):
-        if not (0 <= idx < self.handset_list.GetItemCount()):
-            return False
-        if self._handset_checkboxes_supported:
-            return self.handset_list.IsItemChecked(idx)
-        return self.handset_list.IsSelected(idx)
-
-    def _set_all_handsets_checked(self, checked):
-        for idx in range(self.handset_list.GetItemCount()):
-            self._set_handset_check(idx, checked)
-
-    def _on_handset_check_changed(self, event):
-        self._refresh_handset_summary()
-        self._terminal_state = None
-        self._set_hint(self._compute_hint_state())
-        self._update_workflow_gating()
-        if event:
-            event.Skip()
+        self.handset.refresh_ports(probe=probe, preserve_checks=preserve_checks)
 
     def _refresh_handset_summary(self):
-        total = self.handset_list.GetItemCount()
-        sel = sum(1 for i in range(total) if self._is_handset_checked(i))
-        self.handset_summary.SetLabel(
-            t("handset.summary").format(selected=sel, total=total))
+        self.handset.refresh_summary()
+
+    def _set_handset_status(self, idx, status):
+        self.handset.set_status(idx, status)
+
+    def _set_handset_progress(self, idx, text):
+        self.handset.set_progress(idx, text)
+
+    def _set_all_handsets_checked(self, checked):
+        self.handset.set_all_checked(checked)
+
+    def _on_handset_check_changed(self, event):
+        self.handset.on_check_changed(event)
 
     def _selected_handset_indices(self):
-        return [i for i in range(self.handset_list.GetItemCount())
-                if self._is_handset_checked(i)]
+        return self.handset.selected_indices()
 
     def _selected_handset_devices(self):
-        return [self._handset_ports[i]["device"]
-                for i in self._selected_handset_indices()]
+        return self.handset.selected_devices()
 
     # ------------------------------------------------------------------
     # Workflow gating: enforce Firmware → Handset → Flash order

--- a/gui_ports.py
+++ b/gui_ports.py
@@ -2,8 +2,15 @@
 Serial port detection and programming cable identification.
 """
 
-import serial
-import serial.tools.list_ports
+# pyserial is optional at import time so this module's cable constants
+# (KNOWN_CABLES / FTDI_VID_PID) can be imported in a headless / test
+# environment. The functions below need it at call time and will raise if it
+# isn't installed.
+try:
+    import serial
+    import serial.tools.list_ports
+except ImportError:
+    serial = None
 
 # Known USB VID:PID pairs for compatible programming cables
 KNOWN_CABLES = {

--- a/tests.py
+++ b/tests.py
@@ -605,9 +605,10 @@ class TestHintCopy(unittest.TestCase):
 
 class TestHandsetStatusConstants(unittest.TestCase):
     """Verify all per-handset status strings used by the batch flash flow are
-    defined in gui_main. After the i18n migration these constants are
-    translation keys (e.g. "status.ready") rather than English literals;
-    the rendering layer translates them at write-time."""
+    defined in gui_handset (the source of truth since the handset behavior was
+    extracted there). These constants are translation keys (e.g. "status.ready")
+    rather than English literals; the rendering layer translates them at
+    write-time."""
 
     EXPECTED_KEYS = {
         "STATUS_UNKNOWN": "status.unknown",
@@ -623,12 +624,12 @@ class TestHandsetStatusConstants(unittest.TestCase):
     def test_status_constants_defined(self):
         import importlib
         try:
-            gm = importlib.import_module("gui_main")
+            gh = importlib.import_module("gui_handset")
         except ImportError:
-            self.skipTest("gui_main not importable in this environment")
+            self.skipTest("gui_handset not importable in this environment")
         for name, expected_key in self.EXPECTED_KEYS.items():
-            self.assertTrue(hasattr(gm, name), f"Missing status constant: {name}")
-            self.assertEqual(getattr(gm, name), expected_key,
+            self.assertTrue(hasattr(gh, name), f"Missing status constant: {name}")
+            self.assertEqual(getattr(gh, name), expected_key,
                              f"{name} should be the i18n key '{expected_key}'")
 
     def test_status_keys_resolve(self):

--- a/tests.py
+++ b/tests.py
@@ -1493,5 +1493,78 @@ class TestColumnsModule(unittest.TestCase):
             self.assertTrue(hasattr(self.c, name))
 
 
+class TestHandsetPortEnumeration(unittest.TestCase):
+    """Pure port-discovery logic from the HandsetController (gui_handset).
+
+    Runs with no pyserial and no display: enumerate_serial_ports takes an
+    injectable comports() so the USB filtering / cable-naming / PC03 detection
+    is testable in isolation, and poll_signature is pure. The threaded/widget
+    parts of the controller are verified against real hardware.
+    """
+
+    class FakePort:
+        def __init__(self, device, vid, pid, description=""):
+            self.device, self.vid, self.pid = device, vid, pid
+            self.description = description
+
+    def setUp(self):
+        import gui_handset
+        self.h = gui_handset
+
+    def _comports(self, *ports):
+        return lambda: list(ports)
+
+    def test_filters_non_usb_ports(self):
+        # A port with no vid/pid (motherboard UART) is dropped.
+        comports = self._comports(
+            self.FakePort("/dev/ttyUSB0", 0x1A86, 0x7523),
+            self.FakePort("/dev/ttyS0", None, None, "onboard"),
+        )
+        ports = self.h.enumerate_serial_ports(comports=comports)
+        self.assertEqual([p["device"] for p in ports], ["/dev/ttyUSB0"])
+
+    def test_names_known_cable_and_flags_pc03(self):
+        comports = self._comports(
+            self.FakePort("/dev/ttyUSB0", 0x0403, 0x6015),   # PC03
+            self.FakePort("/dev/ttyUSB1", 0x1A86, 0x7523),   # CH340
+        )
+        ports = self.h.enumerate_serial_ports(comports=comports)
+        self.assertEqual(ports[0]["cable"], "FTDI FT231X (PC03)")
+        self.assertTrue(ports[0]["is_pc03"])
+        self.assertEqual(ports[1]["cable"], "CH340")
+        self.assertFalse(ports[1]["is_pc03"])
+
+    def test_unknown_cable_falls_back_to_description(self):
+        comports = self._comports(
+            self.FakePort("/dev/ttyUSB0", 0x1234, 0x5678, "Acme UART"))
+        ports = self.h.enumerate_serial_ports(comports=comports)
+        self.assertEqual(ports[0]["cable"], "Acme UART")
+
+    def test_initial_status_is_unknown(self):
+        comports = self._comports(self.FakePort("/dev/ttyUSB0", 0x1A86, 0x7523))
+        ports = self.h.enumerate_serial_ports(comports=comports)
+        self.assertEqual(ports[0]["status"], self.h.STATUS_UNKNOWN)
+        self.assertEqual(ports[0]["progress"], "")
+
+    def test_poll_signature_is_order_independent(self):
+        a = {"device": "/dev/ttyUSB0"}
+        b = {"device": "/dev/ttyUSB1"}
+        self.assertEqual(self.h.poll_signature([a, b]),
+                         self.h.poll_signature([b, a]))
+
+    def test_poll_signature_changes_on_plug_unplug(self):
+        one = [{"device": "/dev/ttyUSB0"}]
+        two = [{"device": "/dev/ttyUSB0"}, {"device": "/dev/ttyUSB1"}]
+        self.assertNotEqual(self.h.poll_signature(one),
+                            self.h.poll_signature(two))
+
+    def test_module_exposes_controller_and_statuses(self):
+        self.assertTrue(hasattr(self.h, "HandsetController"))
+        for name in ("STATUS_UNKNOWN", "STATUS_PROBING", "STATUS_READY",
+                     "STATUS_NO_RESP", "STATUS_FLASHING", "STATUS_DONE",
+                     "STATUS_FAILED", "STATUS_SKIPPED"):
+            self.assertTrue(hasattr(self.h, name))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The deepest remaining slice of decomposing `FlasherFrame` — the handset column's **runtime behavior**. The prior GUI PRs moved *construction*; this moves the *controller*: port discovery, the 2-second plug/unplug poll thread, the probe thread, per-row status/progress/checkbox updates, and the selection summary, out of the frame into a `HandsetController` in `gui_handset.py`.

> ⚠️ **Needs a hardware test before merge.** Unlike the earlier slices, this is threads + serial + live widget state, which CI can't exercise. Holding in draft until it's verified on a real radio (see checklist below).

## What moved

- **`HandsetController`** owns the port model (`ports`, `_probing`, `_poll_signature`) and drives the wx `ListCtrl`. It collaborates with the frame for what only the frame provides: the list/summary/refresh widgets, the `_busy`/`_closing` flags, protocol dispatch (`_driver_for`/`_get_selected_radio`), the dialout-permission hint, and the workflow feedback triggered on selection changes.
- The frame keeps **thin delegators** (`_set_handset_status`, `_selected_handset_devices`, a `_handset_ports` property, `_refresh_handset_ports`, …) so the flash-worker `wx.CallAfter` chains, workflow gating, `gui_columns`, and `retranslate_ui` all call the exact same names — **zero churn at those call sites**, which keeps the risky worker-thread code untouched.
- **`STATUS_*`** (the handset-status vocabulary) moves to `gui_handset`, shared by the controller and the flash workers.

## Testable core (headless)

`enumerate_serial_ports(comports=…)` takes an injectable `comports()` and `poll_signature(ports)` is pure, so the USB filtering / cable-naming / PC03 detection / plug-unplug change-detection are now unit-tested with **no pyserial and no display**. The threaded + widget parts are what the hardware test covers.

Also guards pyserial's import in `gui_ports` (matching the `flash_firmware`/`flash_btf` pattern) so its cable constants load headlessly, and drops now-dead `gui_ports` imports from `gui_main`.

## Behavior

Intended to be identical — same enumeration, same probe dispatch, same auto-check/gating/summary, same poll cadence, same construction order.

**7 new unit tests (150 → 157):** USB filtering, known-cable naming + PC03 flag, unknown-cable fallback, initial status, order-independent signature, plug/unplug signature change, and the module/status contract. `python3 tests.py` → 157 passed, 8 skipped (GUI tests needing wxPython, run in CI). `gui_main.py` drops ~190 lines to **~1,828** (from ~2,305 at the start of the decomposition).

## Manual test checklist (on a real radio)

1. **Enumeration** — launch with a cable plugged; the handset list shows it with the right cable name.
2. **Hot-plug** — unplug/replug; the list updates within ~2s and keeps your checkbox state.
3. **Probe** — pick the radio + firmware to unlock the column, hit Refresh: rows go Probing… → Ready / No response; a PC03/FTDI cable auto-checks.
4. **Selection** — check/uncheck; the summary count updates and the Flash column gates correctly (1 = ready, 2+ = batch). Select all / none work.
5. **Flash** — flash a radio (or dry-run): per-port status/progress update live (Flashing → % → Done, or Failed).
6. **Language** — switch language: column headers + statuses re-render.
7. *(Linux, optional)* if not in `dialout`, the permission hint appears once instead of every row going "No response".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHiNfFekn5qV5ebVNyv8y)_