### PR TITLE
Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,8 +21,8 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -94,7 +94,7 @@ jobs:
             icon_128.png=/usr/share/icons/hicolor/128x128/apps/flintwave-flash.png
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-packages
           path: |
@@ -105,8 +105,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -159,7 +159,7 @@ jobs:
         run: iscc installer.iss
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-packages
           path: |
@@ -169,8 +169,8 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -199,7 +199,7 @@ jobs:
           || true
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-packages
           path: |
@@ -212,7 +212,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
 
       - name: List artifacts
         run: find . -type f -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" | sort

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Use the system Python (3.12 on ubuntu-latest) together with the
       # apt-packaged dependencies — this mirrors the project's documented


### PR DESCRIPTION
## Summary

The v26.07.0 release run logged deprecation warnings for actions targeting Node 20. This bumps every action in `tests.yml` and `build-release.yml` to the current Node 24 majors:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

No workflow configuration changes are required: the uploads use plain `name` + `path`, and the release job's bare `download-artifact` (no inputs → all artifacts, each into a directory named after the artifact) behaves the same across these majors, so the `linux-packages/…` / `windows-packages/…` / `macos-packages/…` paths the release script relies on are unchanged.

The `tests.yml` bump is exercised by this PR's own CI; the release-job bumps get their first real run on the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD