### PR TITLE
OpenSpec proposals for the six roadmap improvements

### DIFF
--- a/openspec/changes/ci-hardening/design.md
+++ b/openspec/changes/ci-hardening/design.md
@@ -1,0 +1,219 @@
+## Context
+
+`tests.yml` today runs one job on `ubuntu-latest`: it installs wxPython via
+the apt package `python3-wxgtk4.0` (using the *system* Python, not
+`actions/setup-python`, specifically to avoid an interpreter mismatch between
+a pip-installed Python and an apt-installed wx binary extension), then runs
+`xvfb-run -a python3 tests.py` because `gui_themes`/`gui_main` import
+`wx.adv` and that import alone needs a display, even off-screen.
+
+`build-release.yml` already has three OS-specific recipes for getting
+wxPython installed and importable, because it builds PyInstaller binaries for
+all three OSes on tag push:
+
+| OS | Python source | wx install |
+|---|---|---|
+| Linux | `apt python3-wxgtk4.0` (system Python) | apt, not pip |
+| Windows | `actions/setup-python@v6` (3.12) | `pip install wxPython --prefer-binary` |
+| macOS | `actions/setup-python@v6` (3.12) | `pip install wxPython --prefer-binary` |
+
+This proposal reuses those exact recipes for the test matrix instead of
+inventing new ones — the release workflow is the existing proof that each
+install path works.
+
+There is no top-level CI job today that lints the workflow YAML itself, and
+no scheduled job at all (both existing workflows are triggered by push/PR/tag
+only).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Run the real (non-skipped) test suite, GUI tests included, on all three
+  OSes users actually run the app on.
+- Keep PR feedback latency close to today's (one wx install + one full
+  `tests.py` run, ~a few minutes) rather than 3x-ing wall-clock time.
+- Lint workflow YAML on every push/PR without duplicating what CodeQL's
+  `actions` analysis already does.
+- Detect a silent vendor firmware repack within a week, automatically,
+  without spamming maintainers with duplicate or false-positive issues.
+
+**Non-Goals:**
+- Multi-Python-version matrix (e.g. 3.11/3.12/3.13). The project targets a
+  single Python 3.12 (per `openspec/project.md`); wx's platform-specific
+  behavior is the axis under test here, not Python-version compatibility.
+  Out of scope for this change.
+- Splitting `tests.py` into a GUI suite and a non-GUI suite as separate
+  files/entry points. The existing per-test `skipTest`/`skipUnless` pattern
+  is left as-is; "GUI tests run" is a side effect of wx being importable in
+  the environment, not a separate `pytest -k` selection.
+- Retrying or "self-healing" firmware URLs. Drift detection only reports;
+  a human still decides whether a repack is legitimate (update the pin) or
+  suspicious (investigate).
+- Auto-updating `firmware_manifest.json` hashes. The drift workflow never
+  writes to the manifest — that stays a human-reviewed PR, consistent with
+  `pin-firmware-hashes`' model of hashes as a reviewed, pinned surface.
+
+## Decisions
+
+### 1. Test matrix shape
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    os: [ubuntu-latest, windows-latest, macos-latest]
+```
+
+One job, one Python version (3.12) per OS — 3 jobs total, not 3×N. Each
+matrix leg's "install dependencies" step is OS-conditional (`if:
+runner.os == 'Linux'` / `'Windows'` / `'macOS'`), lifted verbatim from
+`build-release.yml`'s three install recipes, so there is exactly one place
+(`build-release.yml`) that has ever had to solve "how do you get wx on this
+OS" from scratch; `tests.yml` just reuses the answer.
+
+`fail-fast: false` is a deliberate trade-off: without it, a flaky/failing
+Windows leg would cancel the in-progress macOS and Linux legs too, and a
+contributor debugging "is this Linux-only?" would get no macOS/Windows
+signal at all. The cost is that a genuinely broken PR burns full
+runner-minutes on all three OSes instead of failing fast on the first. Given
+this repo's low PR volume and the value of "which OS(es) does this break"
+as debugging signal, correctness-of-signal wins over saving runner-minutes.
+
+Kept at one Python version deliberately (see Non-Goals) — a 3 OS × 2+ Python
+matrix would 6x today's CI cost for a variable (Python version) this project
+has never varied in production or in `build-release.yml`.
+
+### 2. Headless display handling per OS
+
+Only Linux GitHub-hosted runners lack a display server; `xvfb-run -a` stays
+Linux-only, exactly as today. Windows and macOS GitHub-hosted runners already
+run an interactive desktop session (Windows: a real desktop session; macOS:
+WindowServer is up), so wx widgets can be created without any headless
+shim — no `xvfb` equivalent is needed or available for those runners. This
+means the matrix's "run tests" step must branch only on how it invokes
+Python (`xvfb-run -a python3 tests.py` on Linux vs. plain `python tests.py`
+elsewhere), not on any other headless-specific setup.
+
+### 3. wx install cost/flakiness per OS
+
+- **Linux**: apt install of a prebuilt `.deb` — fast (~seconds), no compile,
+  no flakiness beyond normal apt mirror hiccups. Unchanged from today.
+- **Windows/macOS**: `pip install wxPython --prefer-binary` pulls a wheel
+  from PyPI when one exists for the runner's Python/OS/arch combination
+  (both do, for CPython 3.12 on Windows x64 and macOS, per
+  `build-release.yml` already doing this successfully for releases). This is
+  the same install path already exercised by every tagged release build, so
+  its cost/flakiness profile is known: a wheel pull, not a source build.
+  Should PyPI lack a wheel for a given runner image update, the job would
+  fall back to a source build (slow, needs system headers) — treated as an
+  existing, shared risk with `build-release.yml`, not something new this
+  change introduces. No extra pinning beyond what `build-release.yml` already
+  uses.
+- Optionally, `actions/setup-python`'s built-in `cache: pip` can be added on
+  the Windows/macOS legs to avoid re-resolving/downloading the same wheel on
+  every run; left as a follow-up rather than blocking this change, since it's
+  a speed optimization, not correctness.
+
+### 4. actionlint vs. CodeQL `Analyze (actions)` — no duplication
+
+Checked what's already running: `gh api repos/.../code-scanning/analyses`
+shows a `codeql:analyze` job with `category: /language:actions` running
+alongside `/language:python` on every push/PR (17 actions rules, 43 python
+rules, both currently 0 findings). That is CodeQL's relatively new "Actions"
+language pack. It is a **security** scanner:
+
+- Script/code injection via untrusted `${{ github.event.*, github.head_ref,
+  ... }}` expansion inline in a `run:` shell block
+- Overly-broad `permissions:` blocks or missing least-privilege scoping
+- Risky trigger patterns (e.g. `pull_request_target` combined with checkout
+  of untrusted code)
+- Credential/secret exposure patterns
+
+`actionlint` is a **schema/lint** tool. It does not overlap with the above;
+it instead catches:
+
+- Invalid YAML / wrong keys / wrong types against the workflow schema
+- Broken `${{ }}` expression syntax, references to undefined contexts,
+  typos in `needs:`/`matrix.*`/`steps.<id>.outputs.*`
+- shellcheck run over every `run:` block (quoting bugs, unset variables,
+  etc. in the bash steps this repo already leans on heavily for AppImage/
+  fpm/Inno Setup scripting)
+- Dead job references, unreachable steps, deprecated syntax (e.g.
+  `::set-output`)
+
+**Conclusion**: zero meaningful overlap. CodeQL's actions pack has never
+been a substitute for a YAML/shell linter and vice versa; both stay. This
+proposal adds `actionlint` as its own job (`.github/workflows/actionlint.yml`
+or a job inside `tests.yml`) using the official `rhysd/actionlint`
+Docker/binary action, running only against `.github/workflows/*.yml`,
+independent of and non-blocking-on the CodeQL workflow.
+
+### 5. Manifest-drift issue lifecycle
+
+Trigger: `on.schedule` weekly cron (e.g. Monday 06:00 UTC) plus
+`workflow_dispatch` for on-demand manual runs. Runs on `ubuntu-latest`; no wx
+needed (pure `requests` + `hashlib`, reusing `firmware_download.py`'s
+existing chunked-hash logic rather than re-implementing it).
+
+Per manifest entry with non-null `firmware_url` **and** non-null
+`firmware_sha256` (entries with either null are out of scope for this
+workflow — a null hash is `pin-firmware-hashes`' concern, a null URL has
+nothing to download):
+
+1. Download with a bounded timeout (connect + read) and a small number of
+   retries with backoff (vendor servers are known to be slow/flaky; this is
+   a weekly job, not latency-sensitive, so patience is cheap). A descriptive
+   `User-Agent` identifies the traffic as the project's bot, not a scraper
+   trying to look like a browser.
+2. Distinguish two outcomes and never conflate them:
+   - **Verified drift**: download succeeded, SHA-256 differs from the pin.
+   - **Could not verify**: download failed after retries (network/vendor
+     issue). This is logged and optionally surfaced as a lower-urgency
+     "unreachable" note, but MUST NOT be reported as drift — a flaky vendor
+     CDN must never manufacture a false "silent repack" alert.
+3. On verified drift: search open issues (via `gh issue list --search
+   "in:title <radio_id> label:firmware-drift" --state open`) before creating
+   anything.
+   - No existing issue → open one, labeled `firmware-drift`, titled
+     `Firmware drift: <radio_id>`, body has expected hash, actual hash,
+     URL, and timestamp.
+   - Existing issue → append a comment with the latest observation
+     (timestamp + hash) instead of opening a duplicate. This mirrors the
+     idempotent "does it already exist? update, don't duplicate" pattern
+     `build-release.yml`'s `release` job already uses for re-triggered tag
+     pushes (`gh release view` → update vs. create).
+4. On a subsequent run where a previously-flagged entry now matches its
+   pin again (maintainer updated the hash, or the vendor reverted): comment
+   on and close the open `firmware-drift` issue for that radio ID rather
+   than leaving it open forever. Only entries that currently have an open
+   drift issue are checked this way — no separate bookkeeping file is
+   needed; "is there an open issue for this radio id" is itself the state.
+5. Entries are checked sequentially, not in parallel, and only once a week —
+   deliberately low request volume per vendor, addressing "don't hammer
+   them."
+
+Permissions: this workflow needs `permissions: issues: write` (and
+`contents: read`) — narrower than blanket `write-all`, and it is the first
+workflow in the repo that writes anything via `GITHUB_TOKEN`, which is worth
+calling out explicitly in review.
+
+## Risks / Trade-offs
+
+- **3x test-job runner-minutes** for every push/PR. Accepted: catching a
+  Windows/macOS-only regression before a tagged release is worth the cost
+  for a project whose users are overwhelmingly on those platforms.
+- **wx install flakiness on Windows/macOS** is a pre-existing risk this
+  change inherits from `build-release.yml`, not one it introduces; if PyPI
+  wheel availability regresses, both workflows are affected and both would
+  need the same fix (e.g. pinning a known-good wxPython version).
+- **Drift workflow false negatives**: a vendor that repacks *and* happens to
+  produce identical bytes some other way, or an entry with a null pin,
+  isn't covered — this is why `pin-firmware-hashes` (all entries pinned) is
+  a prerequisite for this workflow's coverage to be complete across the
+  whole manifest, not just the two `bf-f8hp-pro*` entries that are pinned
+  today.
+- **GitHub Issues as the notification channel**: no email/Slack alerting is
+  in scope; someone has to be watching the repo's issues (or its
+  notifications) for the weekly run to be acted on promptly. Acceptable for
+  this project's scale; revisit if response time to drift issues becomes a
+  problem.

--- a/openspec/changes/ci-hardening/proposal.md
+++ b/openspec/changes/ci-hardening/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+CI has three gaps that would each have caught (or would help catch) real problems:
+
+1. **`tests.yml` only runs on `ubuntu-latest`.** Most users run the released
+   Windows/macOS binaries (see `build-release.yml`), but wxPython's behavior —
+   layout, native widget quirks, theme rendering, RTL — genuinely differs per
+   platform. A regression that only breaks the Windows or macOS build is
+   invisible to CI until a user reports it against a tagged release.
+
+2. **Workflow YAML has no linter.** CodeQL's `Analyze (actions)` job already
+   scans `.github/workflows/*.yml` (visible in the repo's code-scanning
+   analyses: category `/language:actions`, 17 rules), but that pack is a
+   *security* scanner — injection via untrusted `${{ }}` expansion in `run:`,
+   excessive `permissions:`, credential handling. It does not validate YAML
+   schema, catch shellcheck-class bugs in `run:` blocks, or flag broken
+   `needs:`/context references. `actionlint` covers exactly that gap and
+   would have caught it earlier, as syntax/typo errors in workflow files
+   currently only surface when a job actually runs (or fails to).
+
+3. **Firmware integrity has no ongoing check.** `pin-firmware-hashes` (see
+   `openspec/changes/pin-firmware-hashes/`) adds pinned SHA-256 hashes to
+   `firmware_manifest.json` and verifies them at *download time* — but that
+   only protects a user who happens to download after a repack is noticed.
+   The 2026-07-10 BaofengTech silent repack (unchanged URL, changed bytes)
+   went undetected for a week because nothing checked the manifest against
+   the live vendor bundle proactively. A scheduled drift check closes that
+   window from "whenever a user notices" to "within a week."
+
+## What Changes
+
+- **Cross-platform test matrix**: extend `tests.yml` to run the full suite
+  (including the ~8 GUI tests that currently self-skip headless) on
+  `windows-latest` and `macos-latest`, reusing the dependency-install recipes
+  `build-release.yml` already has working for each OS. `fail-fast: false` so
+  one platform's failure doesn't hide the others' results.
+- **actionlint job**: add a fast, dependency-light job that lints every
+  `.github/workflows/*.yml` file on every push/PR, distinct from and
+  complementary to the existing CodeQL `actions` analysis.
+- **Scheduled manifest-drift workflow**: a new weekly-cron workflow that
+  re-downloads every `firmware_manifest.json` entry with a non-null
+  `firmware_url` *and* non-null `firmware_sha256`, recomputes SHA-256, and
+  compares against the pinned value. On mismatch it opens (or updates, never
+  duplicates) a GitHub issue; if a previously-flagged entry now matches again
+  it closes the issue.
+
+## Capabilities
+
+### New Capabilities
+- `ci`: cross-platform test execution, workflow linting, and scheduled
+  firmware-manifest drift detection — the non-functional guarantees the
+  project's CI provides about itself and about the firmware supply chain.
+
+## Impact
+
+- **Affected files**: `.github/workflows/tests.yml` (matrix expansion),
+  new `.github/workflows/actionlint.yml`, new
+  `.github/workflows/manifest-drift.yml`. No application source code changes.
+- **CI cost/time**: test job count goes from 1 to 3 (roughly 3x total
+  runner-minutes for the test suite); actionlint job is seconds-scale;
+  drift workflow runs once a week, off the PR critical path.
+- **Permissions**: the drift workflow needs `issues: write` (new) in
+  addition to `contents: read`; it is the first workflow in this repo to
+  write anything via `GITHUB_TOKEN`.
+- **External dependency**: the drift workflow depends on vendor servers
+  (BaofengTech, Radtel/Shopify CDN) being reachable; failures there must
+  degrade to "couldn't verify" rather than a false drift report or a hard
+  CI failure.
+- **No user-facing or protocol changes.**

--- a/openspec/changes/ci-hardening/specs/ci/spec.md
+++ b/openspec/changes/ci-hardening/specs/ci/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Cross-platform test execution
+The test suite (`tests.py`) SHALL run to completion on `ubuntu-latest`,
+`windows-latest`, and `macos-latest` on every push to `master` and every
+pull request, with wxPython installed and importable on all three, so that
+GUI tests exercise real widget behavior on each platform instead of
+self-skipping.
+
+#### Scenario: PR touching GUI code runs on all three OSes
+- **WHEN** a pull request is opened or updated
+- **THEN** the `test` job runs as a matrix over `ubuntu-latest`,
+  `windows-latest`, and `macos-latest` with `fail-fast: false`, and each
+  matrix leg installs wxPython using the OS-appropriate recipe (apt on
+  Linux; `pip install wxPython --prefer-binary` on Windows/macOS)
+
+#### Scenario: GUI tests execute rather than skip on every OS
+- **WHEN** the test suite runs on any of the three matrix legs
+- **THEN** tests that call `self.skipTest(...)` when `gui_themes`,
+  `gui_main`, or `gui_handset` are not importable SHALL NOT skip — wx SHALL
+  be importable on all three legs, and the reported test count SHALL
+  include those GUI-dependent tests as executed, not skipped
+
+#### Scenario: Linux leg still runs headless
+- **WHEN** the Linux matrix leg runs the test suite
+- **THEN** it SHALL invoke the suite under `xvfb-run` (or equivalent) so
+  that importing `wx.adv` succeeds without a real display, exactly as it
+  does today
+
+#### Scenario: One OS failing does not hide the others
+- **WHEN** the test suite fails on exactly one OS in the matrix (e.g.
+  Windows)
+- **THEN** the Linux and macOS legs SHALL still run to completion and
+  report their own pass/fail status, rather than being cancelled
+
+### Requirement: Workflow files are linted
+Every workflow file under `.github/workflows/` SHALL be checked by
+`actionlint` on every push and pull request, independent of and
+non-duplicative of the existing CodeQL `Analyze (actions)` job.
+
+#### Scenario: A workflow YAML/shell error is introduced
+- **WHEN** a pull request modifies a `.github/workflows/*.yml` file to
+  introduce a schema error (invalid key), a broken `${{ }}` expression, or
+  a shellcheck-flagged bug in a `run:` block
+- **THEN** the actionlint job SHALL fail on that pull request before merge
+
+#### Scenario: actionlint job scope stays read-only
+- **WHEN** the actionlint job runs
+- **THEN** it SHALL run with `permissions: contents: read` only — it never
+  needs write access to the repository
+
+### Requirement: Firmware manifest drift is detected on a schedule
+A weekly scheduled workflow SHALL re-verify every `firmware_manifest.json`
+entry that has both a non-null `firmware_url` and a non-null
+`firmware_sha256` against the live vendor bundle, and SHALL surface any
+detected drift as a GitHub issue rather than failing silently or
+duplicating existing reports.
+
+#### Scenario: Vendor silently repacks a pinned bundle
+- **WHEN** the weekly drift-check workflow downloads the bundle at a pinned
+  entry's `firmware_url` and its recomputed SHA-256 does not match the
+  manifest's `firmware_sha256`
+- **THEN** the workflow SHALL search open issues for an existing
+  `firmware-drift`-labeled issue referencing that radio id before creating
+  one, SHALL open a new issue only if none exists, and the issue body SHALL
+  contain the expected hash, the actual hash, the URL, and the detection
+  timestamp
+
+#### Scenario: Drift already reported and still present
+- **WHEN** the weekly workflow re-detects the same hash mismatch for a
+  radio id that already has an open `firmware-drift` issue
+- **THEN** the workflow SHALL add a comment to the existing issue instead
+  of opening a duplicate issue
+
+#### Scenario: Previously drifted entry is corrected
+- **WHEN** the weekly workflow finds that a radio id with an open
+  `firmware-drift` issue now matches its pinned hash again (manifest was
+  updated, or the vendor reverted the bundle)
+- **THEN** the workflow SHALL comment on and close the existing issue for
+  that radio id
+
+#### Scenario: Vendor server is unreachable or slow
+- **WHEN** downloading a manifest entry's bundle fails after the
+  workflow's configured retries (timeout, connection error, non-2xx
+  response)
+- **THEN** the workflow SHALL record this as "could not verify" for that
+  entry and SHALL NOT open or update a `firmware-drift` issue for it — a
+  transient vendor/network failure SHALL NOT be reported as drift
+
+#### Scenario: Entries out of scope for drift checking
+- **WHEN** a manifest entry has a null `firmware_url` or a null
+  `firmware_sha256`
+- **THEN** the drift-check workflow SHALL skip that entry without error and
+  without opening any issue for it
+
+#### Scenario: Vendor servers are not hammered
+- **WHEN** the drift-check workflow runs
+- **THEN** it SHALL run on a weekly cron schedule (plus manual
+  `workflow_dispatch`), SHALL process manifest entries sequentially, and
+  SHALL NOT run on every push or pull request

--- a/openspec/changes/ci-hardening/tasks.md
+++ b/openspec/changes/ci-hardening/tasks.md
@@ -1,0 +1,46 @@
+## 1. Cross-platform test matrix (`tests.yml`)
+
+- [ ] 1.1 Add `strategy: fail-fast: false, matrix: os: [ubuntu-latest, windows-latest, macos-latest]` to the existing `test` job
+- [ ] 1.2 Split the "Install dependencies" step into three OS-conditional steps (`if: runner.os == 'Linux' / 'Windows' / 'macOS'`), reusing the exact recipes from `build-release.yml`:
+  - Linux: `apt-get install python3-wxgtk4.0 python3-serial python3-requests xvfb` (system Python, unchanged from today)
+  - Windows: `actions/setup-python@v6` (3.12) + `pip install pyserial requests wxPython --prefer-binary`
+  - macOS: `actions/setup-python@v6` (3.12) + `pip install pyserial requests wxPython --prefer-binary`
+- [ ] 1.3 Make the "Run test suite" step OS-conditional: `xvfb-run -a python3 tests.py` on Linux, plain `python tests.py` (Windows uses `python`, not `python3`) on Windows/macOS
+- [ ] 1.4 Keep the "Show environment" sanity step (`import wx, serial, requests`) on all three legs so a broken wx install fails fast with a clear message instead of a wall of skipped-test noise
+- [ ] 1.5 Confirm the ~8 GUI tests that currently skip headless (`gui_themes`, `gui_main`/`HINT_STATES`, `gui_handset` status constants, etc. — see `tests.py`) actually execute (not skip) on all three OSes; check the run's test count/output, not just exit code
+- [ ] 1.6 Update the README `Tests` badge/CI description if it currently implies Linux-only coverage
+- [ ] 1.7 Land and observe at least one full matrix run on a real PR before merging to `master`, to catch any OS-specific test flakiness (e.g. path separators, timing) before it's the default gate
+
+## 2. actionlint job
+
+- [ ] 2.1 Add a job (new `.github/workflows/actionlint.yml`, or a job appended to `tests.yml`) that runs `rhysd/actionlint` (official Docker/binary action) against `.github/workflows/*.yml`
+- [ ] 2.2 Scope its trigger to `push`/`pull_request` like `tests.yml`, and to changes touching `.github/workflows/**` at minimum (may run unconditionally too, since it's fast)
+- [ ] 2.3 Run it once against the current `tests.yml`/`build-release.yml` as a smoke test; fix any pre-existing findings (e.g. unquoted `run:` expressions, unpinned action shas) surfaced, or explicitly note them as accepted/deferred
+- [ ] 2.4 Confirm this job's `permissions:` block is read-only (`contents: read`) — it never needs write access
+- [ ] 2.5 Document in the job (a comment) that this is intentionally separate from and non-duplicative of the existing CodeQL `Analyze (actions)` job — see `design.md` §4 for the conclusion
+
+## 3. Scheduled manifest-drift workflow
+
+- [ ] 3.1 Create `.github/workflows/manifest-drift.yml` with `on: schedule` (weekly cron) + `on: workflow_dispatch` for manual runs
+- [ ] 3.2 Set `permissions: issues: write, contents: read` (narrowest scope that can search/create/comment/close issues)
+- [ ] 3.3 Write the drift-check script (inline Python step, reusing `firmware_download.py`'s chunked SHA-256 logic rather than re-implementing hashing) that:
+  - [ ] 3.3.1 Loads `firmware_manifest.json`, iterates entries where `firmware_url is not null and firmware_sha256 is not null`
+  - [ ] 3.3.2 Downloads each with a bounded timeout and a small retry/backoff count; sets a descriptive `User-Agent`
+  - [ ] 3.3.3 Computes SHA-256 of the download and compares to the pinned value
+  - [ ] 3.3.4 Distinguishes "verified drift" (hash mismatch) from "could not verify" (download failed after retries) and never reports the latter as drift
+  - [ ] 3.3.5 Processes entries sequentially (not in parallel) to avoid hammering vendor servers
+- [ ] 3.4 Wire up issue lifecycle via `gh` CLI:
+  - [ ] 3.4.1 On verified drift: `gh issue list --search "<radio_id> in:title label:firmware-drift" --state open` first
+  - [ ] 3.4.2 No match → `gh issue create` labeled `firmware-drift`, titled `Firmware drift: <radio_id>`, body with expected hash, actual hash, URL, timestamp
+  - [ ] 3.4.3 Match found → `gh issue comment` on the existing issue instead of creating a duplicate
+  - [ ] 3.4.4 On a subsequent run where a previously-flagged entry now matches again → comment and `gh issue close` the open issue for that radio id
+- [ ] 3.5 Create the `firmware-drift` label in the repo (or have the workflow create it on first use via `gh label create` if missing)
+- [ ] 3.6 Add a "could not verify" log/summary output (job summary, not an issue) for entries whose download failed, so maintainers can distinguish "vendor CDN was flaky this week" from silence
+- [ ] 3.7 Trigger a manual `workflow_dispatch` run against the current manifest as a smoke test; confirm it correctly reports no drift for the two pinned entries (`bf-f8hp-pro`, `bf-f8hp-pro-nrfb`) and correctly skips the three unpinned/null-URL entries
+- [ ] 3.8 Note in the workflow file (comment) that full manifest coverage depends on `pin-firmware-hashes` landing — until all entries are pinned, this workflow only protects the currently-pinned subset
+
+## 4. Cross-cutting
+
+- [ ] 4.1 `openspec validate ci-hardening --strict` passes
+- [ ] 4.2 `CHANGELOG.md` entry noting the expanded test matrix, actionlint gate, and scheduled drift check
+- [ ] 4.3 Each group above (1, 2, 3) is landable and reviewable as its own PR — no group depends on another shipping first

--- a/openspec/changes/decompose-gui-main-workers/design.md
+++ b/openspec/changes/decompose-gui-main-workers/design.md
@@ -1,0 +1,207 @@
+# Decompose gui_main Workers — Design
+
+## What remains on the frame today
+
+`gui_main.py` after PR #19 groups into these responsibilities (line ranges
+approximate, current file):
+
+| Block | Methods | Lines |
+| --- | --- | --- |
+| Frame construction | `__init__` | 54–282 |
+| i18n / retranslate | `_tr_label`, `_tr_tooltip`, `_resolve_direction`, `_language_button_label`, `_open_language_dialog`, `retranslate_ui`, `_refresh_radio_dropdown` | 287–495 |
+| Layout / theme | `_column_heading`, `_toggle_theme`, `_on_hints_size` | 501–536 |
+| Handset delegators | `_handset_ports` … `_selected_handset_devices` | 547–576 |
+| Workflow gating | `_firmware_ready`, `_handset_ready`, `_update_workflow_gating`, `_pulse_arrow` | 582–710 |
+| Font controls | `_set_font_size`, `_cycle_font` | 716–780 |
+| **Hint state machine** | `_get_hint_copy`, `_format_radio_info`, `_set_hint`, `_compute_hint_state`, `_on_state_change` | 786–894 |
+| Menu handlers | `on_usage_guide`, `on_github`, `on_about`, `_on_close` | 900–921 |
+| **Updater / manifest** | `_fetch_manifest`, `_check_update`, `_notify_update`, `_show_update_link` | 927–977 |
+| **Firmware discovery** | `_get_selected_radio`, `_driver_for`, `_get_firmware_url_and_version`, `_update_radio_info`, `on_radio_changed` | 979–1043 |
+| **Download worker** | `on_download`, `_download_thread`, `on_browse` | 1045–1121 |
+| **Worker plumbing** | `log_msg`, `set_progress`, `set_buttons` | 1123–1151 |
+| **Flash workers** | `on_flash`, `_batch_flash_thread`, `_prompt_continue_batch`, `_flash_thread`, `_flash_thread_btf`, `_is_permission_denied`, `_log_dialout_hint`, `_offer_test_report`, `_offer_firmware_cleanup` | 1153–1593 |
+| **Dry-run worker** | `on_dry_run`, `_dryrun_thread` | 1595–1712 |
+| **Diagnostics worker** | `on_diag`, `_diag_thread` | 1714–1796 |
+| Module entry | `detect_os_theme`, `main` | 1799–1828 |
+
+The bold blocks are what this change extracts. The non-bold blocks stay on the
+frame as the coordinator core (a later change may extract i18n and font/theme).
+
+## Collaboration idiom being reused
+
+The gui_handset extraction sets the contract this change follows:
+
+- The component takes `frame` in its constructor and reaches back through it for
+  everything only the frame owns (widgets, `_busy`/`_closing` flags, protocol
+  dispatch, cross-component feedback).
+- The frame publishes the component (`self.handset = HandsetController(self)`)
+  and exposes **thin same-named delegators** (`_set_handset_status` →
+  `self.handset.set_status`) plus **property shims** for state the old code read
+  as an attribute (`_handset_ports` → `self.handset.ports`).
+- Every worker→widget update goes through `wx.CallAfter`; the component never
+  touches a widget from a background thread directly.
+- Pure logic (`enumerate_serial_ports`, `poll_signature`) is module-level and
+  injectable so it unit-tests without pyserial or a display; the threaded/widget
+  half is verified against hardware.
+
+Each slice below is a straight application of that idiom.
+
+---
+
+## Slice 1 — `gui_hints` (HintPresenter)
+
+**Moves:** `_get_hint_copy`, `_format_radio_info`, `_set_hint`,
+`_compute_hint_state`, `_on_state_change`, and the `HINT_STATES` /
+`_RADIO_INFO_STATES` bindings. `_format_radio_info` is refactored into a
+module-level pure `format_radio_info(radio, url_version)` that takes the radio
+dict and resolved firmware version and returns the string (the frame passes
+`_get_firmware_url_and_version(radio)` in), so the string-building is testable
+with no widgets.
+
+**Stays on the frame:** the `hint_text` TextCtrl (built in `__init__`), and the
+state the presenter reads — `_get_selected_radio`, `_get_firmware_url_and_version`,
+`_firmware_ready`, `_selected_handset_indices`, and the `_busy` / `_terminal_state`
+/ `_busy_state` / `font_size` fields. The presenter holds `frame` and reads these
+through it, exactly as HandsetController does.
+
+**Collaboration contract:** frame keeps delegators `_set_hint`,
+`_compute_hint_state`, `_format_radio_info`, `_on_state_change`, and the class
+attributes `HINT_STATES` / `_RADIO_INFO_STATES` (referenced by tests and by
+`retranslate_ui`). Call sites that keep working unchanged: `retranslate_ui`
+(`_set_hint(self._compute_hint_state())`), HandsetController
+(`frame._set_hint`, `frame._compute_hint_state` in `on_check_changed` /
+`_probe_thread`), `_update_workflow_gating`, `_update_radio_info`, and every
+worker's `wx.CallAfter(lambda: self._set_hint(self._compute_hint_state()))`.
+
+**Risk: low.** No threads, no serial. `_set_hint` renders into a TextCtrl on the
+GUI thread (workers already marshal to it via `wx.CallAfter`), so the widget
+contact is unchanged.
+
+**Test strategy:** the decision half is already pure and covered
+(`gui_workflow.compute_hint_state`, `TestWorkflowStateMachine`,
+`TestHintCopy`) — those stay green untouched. Add a headless unit for the new
+`format_radio_info` pure helper (bootloader-keys / connector / tested / notes /
+latest-version formatting) following the `TestHandsetPortEnumeration` skip-if-
+unimportable pattern. No `mock_bootloader`, no hardware.
+
+---
+
+## Slice 2 — `gui_download` (DownloadController)
+
+**Moves:** the download worker (`on_download`, `_download_thread`, `on_browse`),
+firmware discovery (`_get_firmware_url_and_version`, `_update_radio_info`,
+`on_radio_changed`), and the updater/manifest background tasks (`_fetch_manifest`,
+`_check_update`, `_notify_update`, `_show_update_link`). `self.manifest` is set by
+the controller and exposed on the frame as a property shim (like
+`_handset_ports`) so hints/flash keep reading `frame.manifest`.
+
+**Stays on the frame:** `_get_selected_radio` and `_driver_for` — both are shared
+by HandsetController (probe), the hint presenter, and the flash workers, so they
+remain frame-level shared helpers, not owned by this controller. Widgets
+`download_btn`, `file_path`, `radio_combo`, `progress`, `update_link`,
+`status_bar_panel` stay frame-owned (built by gui_columns / gui_statusbar); the
+controller drives them through the frame via `wx.CallAfter`.
+
+**Collaboration contract:** delegators kept on the frame — `on_download`,
+`on_browse`, `on_radio_changed` (bound by gui_columns to `frame.on_*`),
+`_update_radio_info` (called by `set_buttons`, `retranslate_ui`, `__init__`, and
+the manifest-fetch `wx.CallAfter`), and `_get_firmware_url_and_version` (read by
+the hint presenter and by `_flash_thread`). Cross-controller reads go through the
+frame delegator surface, matching how HandsetController calls `frame._driver_for`.
+
+**Risk: medium.** Two background threads (`_check_update`, `_fetch_manifest`) and
+the download worker touch the network, the filesystem, and status-bar / download-
+button widgets — but **no serial and no live-radio state**, so **no hardware
+checklist is required**. The main hazards are `wx.CallAfter` ordering against
+`_closing` (already guarded in `_notify_update` / `_update_radio_info`) and the
+`_busy` interlock the download worker shares with flashing.
+
+**Test strategy:** exercise the worker orchestration with the existing mocked
+seams — `TestDownloader` (`dl.download_and_extract`) and `TestUpdater`
+(`updater.check_for_update`). Add a headless unit asserting `_download_thread`
+scales progress to 80 % for the download phase and sets `_terminal_state`
+correctly on success/failure with a fake `dl`. No `mock_bootloader`, no hardware.
+
+---
+
+## Slice 3 — `gui_flash` (FlashController)
+
+**Moves:** the serial operation workers and their plumbing — `on_flash`,
+`_flash_thread`, `_flash_thread_btf`, `_batch_flash_thread`,
+`_prompt_continue_batch`, `on_dry_run`, `_dryrun_thread`, `on_diag`,
+`_diag_thread`, `_offer_test_report`, `_offer_firmware_cleanup`, and the worker
+plumbing `log_msg`, `set_progress`, `set_buttons`.
+
+**Stays on the frame:** `_is_permission_denied` and `_log_dialout_hint` remain
+frame-level shared serial-error helpers — HandsetController's `_probe_thread`
+already calls `frame._log_dialout_hint`, so moving them would only add a reverse
+dependency for no benefit. Shared helpers `_get_selected_radio`,
+`_driver_for`, `_get_firmware_url_and_version` stay on the frame; the controller
+reads them through `frame`. Widgets (`flash_btn`, `progress`, `log`, `file_path`,
+handset list via the existing `_set_handset_status`/`_set_handset_progress`
+delegators) stay frame/handset-owned.
+
+**Collaboration contract:** delegators kept on the frame — `on_flash`,
+`on_dry_run`, `on_diag` (bound by gui_columns), and `log_msg`, `set_progress`,
+`set_buttons` (called from the workers and reused wherever progress/log is
+posted). The batch path keeps calling `frame._set_handset_status` /
+`_set_handset_progress` / `_selected_handset_indices` (HandsetController
+delegators) and the `STATUS_*` constants imported from gui_handset — unchanged.
+
+**Risk: high.** Threads + serial + live widgets. Per project convention this
+slice **requires the manual hardware checklist (PR #19 pattern) before merge.**
+
+**Test strategy — two commits:**
+1. *Move-only* (preserve behavior): relocate the workers verbatim behind the
+   controller. Verified by the hardware checklist (single-flash, batch, BTF,
+   dry-run, diagnostics on a real radio) plus the unchanged end-to-end
+   `mock_bootloader` driver tests (`TestEndToEndFlashKDH`, `TestEndToEndFlashBTF`,
+   `TestBatchFlashRouting`), which cover the driver level the batch path already
+   uses.
+2. *Driver convergence* (closes the headless-coverage gap): the single-flash KDH
+   `_flash_thread`, the KDH branch of `_dryrun_thread`, and `_diag_thread`
+   currently hand-roll `serial.Serial` + `send_command` inline, so they have **no
+   headless coverage**. Converge them onto the already-tested driver functions
+   `fw.flash_to_port` / `fw.dry_run` / `fw.run_diagnostics` (the batch path
+   already uses `driver.flash_to_port`). The GUI worker then becomes a thin
+   wrapper testable with `mock_bootloader.patch_serial`, matching `_flash`
+   in `TestEndToEndFlashKDH`. This is behavior-adjacent, so it stays a separate
+   commit and re-runs the hardware checklist.
+
+---
+
+## Why this order
+
+The slices have no hard dependency on each other (each is a self-contained
+move-plus-delegator), so ordering is chosen for **safest incremental merges,
+lowest-risk-first**, with a secondary rationale that earlier slices stabilize the
+surfaces the later ones lean on:
+
+1. **Hints first** — zero threads/serial, smallest blast radius, and it hardens
+   the presentation surface (`_set_hint` / `_compute_hint_state`) that all three
+   workers call. Extracting it before the workers means the Slice 3 move lands
+   against a delegator that is already stable rather than a method that is itself
+   about to move.
+2. **Download second** — network-only, no hardware gate, so it can merge on CI
+   evidence alone. It isolates firmware discovery (`_get_firmware_url_and_version`,
+   `manifest`) that both the hint presenter and the flash workers read, giving
+   Slice 3 a settled dependency.
+3. **Flash last** — the highest-value slice (the change's namesake) but the only
+   one that needs the hardware checklist. Sequencing it last lets it lean on the
+   now-stable hint and firmware-info delegators and keeps the risky, slow-to-
+   verify change off the critical path of the two cheap wins.
+
+An alternative "unblocking-value-first" order would put Flash first because it is
+the point of the change; it is rejected because the flash slice is exactly the one
+whose verification is slowest (hardware) and whose correctness most benefits from
+the other two surfaces already being stable.
+
+## Residual frame after this change (future slices, out of scope)
+
+After the three slices, `gui_main.py` retains construction, i18n/retranslate
+plumbing, workflow gating, font/theme controls, menu handlers, and the shared
+`_get_selected_radio` / `_driver_for` helpers. Two further slices are noted for a
+later change: **`gui_i18n`** (retranslate registry + language dialog +
+`_refresh_radio_dropdown`) and **`gui_appearance`** (`_set_font_size` /
+`_cycle_font` / `_toggle_theme` / `_pulse_arrow`). They are deliberately excluded
+here to keep this change scoped to the worker decomposition its id names.

--- a/openspec/changes/decompose-gui-main-workers/proposal.md
+++ b/openspec/changes/decompose-gui-main-workers/proposal.md
@@ -1,0 +1,78 @@
+# Decompose gui_main Workers — Proposal
+
+## Why
+
+`gui_main.py` (`FlasherFrame`) is still ~1,828 lines after four extraction PRs
+(gui_titlebar #16, gui_statusbar #17, gui_columns #18, gui_handset #19). The
+established pattern works: construction and behavior move into a component
+module, the frame keeps thin same-named delegators so worker-thread
+`wx.CallAfter` chains and cross-module call sites (gui_columns bindings,
+HandsetController) don't churn, and protocol-adjacent logic gets pure/injectable
+helpers that are unit-tested headlessly.
+
+What remains on the frame is dominated by a single unextracted responsibility:
+the **operation worker threads**. Roughly 750 lines (lines ~1045–1796) are the
+flash / batch-flash / BTF-flash / download / dry-run / diagnostics handlers and
+their background threads, plus their shared plumbing (`log_msg`, `set_progress`,
+`set_buttons`, permission-error hints, test-report offer). Two supporting
+concerns are tangled in with them — the hint/radio-info presentation the workers
+drive, and the firmware-discovery + updater plumbing they depend on.
+
+This coupling has a concrete cost: the batch-flash path already delegates to the
+mock-testable driver function `driver.flash_to_port` and is covered end-to-end by
+`mock_bootloader`, but the **single-flash KDH path (`_flash_thread`), the KDH
+`_dryrun_thread`, and `_diag_thread` hand-roll the serial protocol inline** and
+so have zero headless coverage — they can only be verified against real hardware.
+Extracting them behind a controller boundary is the precondition for closing that
+gap.
+
+## What Changes
+
+Three independently-mergeable extraction slices, each keeping the suite green and
+shipping as its own PR, ordered lowest-risk-first:
+
+1. **Slice 1 — `gui_hints` (HintPresenter):** move the hint state machine and
+   per-radio info rendering (`_get_hint_copy`, `_format_radio_info`, `_set_hint`,
+   `_compute_hint_state`, `_on_state_change`, `HINT_STATES`/`_RADIO_INFO_STATES`)
+   into a presenter. No threads, no serial. Frame keeps same-named delegators;
+   `_format_radio_info` becomes a pure `format_radio_info(radio, …)` helper unit-
+   tested without a display. **Risk: low.**
+
+2. **Slice 2 — `gui_download` (DownloadController):** move firmware acquisition
+   and update notification — the download worker (`on_download`, `_download_thread`,
+   `on_browse`), firmware discovery (`_get_firmware_url_and_version`,
+   `_update_radio_info`, `on_radio_changed`), and the updater/manifest background
+   tasks (`_fetch_manifest`, `_check_update`, `_notify_update`, `_show_update_link`).
+   Network + file + status-bar widgets only — **no serial, no hardware gate.**
+   Testable with the existing mocked-`dl`/`updater` suites. **Risk: medium.**
+
+3. **Slice 3 — `gui_flash` (FlashController):** move the serial operation workers —
+   `on_flash`/`_flash_thread`/`_flash_thread_btf`/`_batch_flash_thread`,
+   `on_dry_run`/`_dryrun_thread`, `on_diag`/`_diag_thread`, plus
+   `_prompt_continue_batch`, `_offer_test_report`, `_offer_firmware_cleanup`, and
+   the worker plumbing (`log_msg`, `set_progress`, `set_buttons`). This is the
+   change's namesake and highest-value slice. It touches threads + serial + live
+   widgets, so it **requires the manual hardware checklist before merge**. A
+   follow-on commit converges the hand-rolled single-flash / dry-run / diagnostics
+   paths onto the already-tested driver functions so the GUI worker becomes a thin,
+   `mock_bootloader`-testable wrapper. **Risk: high.**
+
+## Impact
+
+- **Affected code:** `gui_main.py` shrinks from ~1,828 to roughly ~950 lines,
+  becoming a coordinator (construction, i18n/retranslate, workflow gating, font/
+  theme, menu handlers). New modules `gui_hints.py`, `gui_download.py`,
+  `gui_flash.py`. Shared helpers `_get_selected_radio` and `_driver_for` stay on
+  the frame (used by handset, hints, flash, and gating alike).
+- **Behavior:** none intended per slice — extractions are move-plus-delegator, and
+  every existing call site keeps its name. The Slice 3 driver-convergence commit is
+  the one behavior-adjacent step and is gated by the hardware checklist.
+- **Tests:** existing pure tests (`gui_workflow`, `gui_handset` enumeration,
+  end-to-end `mock_bootloader` flash) stay green unchanged. New headless units for
+  `format_radio_info` and, after Slice 3 convergence, `mock_bootloader` coverage of
+  the single-flash / dry-run / diagnostics GUI wrappers.
+- **Backwards compatible:** no user-facing change; `radios.json` /
+  `firmware_manifest.json` / i18n catalogs untouched.
+- **Deferred (out of scope):** i18n/retranslate plumbing and font/theme controls
+  remain on the frame; they are noted in design.md as future slices once the
+  worker decomposition lands.

--- a/openspec/changes/decompose-gui-main-workers/specs/gui-architecture/spec.md
+++ b/openspec/changes/decompose-gui-main-workers/specs/gui-architecture/spec.md
@@ -1,0 +1,120 @@
+# GUI Architecture Specification
+
+Delta for the ongoing decomposition of `gui_main.py` (`FlasherFrame`) into
+collaborating component modules. These requirements codify the invariants the
+existing extractions (gui_titlebar, gui_statusbar, gui_columns, gui_handset,
+gui_workflow) already follow, and that this change's three new slices
+(`gui_hints`, `gui_download`, `gui_flash`) MUST also follow.
+
+## ADDED Requirements
+
+### Requirement: Component extraction preserves call-site names
+
+When behavior is moved from `FlasherFrame` into a component module, the frame
+SHALL retain a thin delegator (or property shim) with the **same name** as the
+moved method or attribute, so that existing cross-module call sites — gui_columns
+event bindings, HandsetController callbacks, `retranslate_ui`, workflow gating,
+and worker `wx.CallAfter` chains — continue to work without modification. An
+extraction SHALL NOT rename or remove a symbol that a call site outside the new
+component still references.
+
+#### Scenario: Worker calls a delegator that was extracted
+
+- **GIVEN** `_set_hint` and `_compute_hint_state` have been moved into a
+  `HintPresenter` component
+- **WHEN** a flash worker thread runs
+  `wx.CallAfter(lambda: self._set_hint(self._compute_hint_state()))`
+- **THEN** the frame SHALL still expose `_set_hint` and `_compute_hint_state` as
+  delegators forwarding to the presenter
+- **AND** the worker source SHALL be unchanged by the extraction
+
+#### Scenario: gui_columns button binding survives extraction
+
+- **GIVEN** `on_download` has been moved into a `DownloadController`
+- **WHEN** `FirmwareColumn` binds its button with
+  `self.download_btn.Bind(wx.EVT_BUTTON, frame.on_download)`
+- **THEN** `frame.on_download` SHALL still resolve to a delegator that invokes the
+  controller
+- **AND** the gui_columns binding SHALL be unchanged
+
+#### Scenario: Attribute read as state survives extraction
+
+- **GIVEN** the manifest is now owned by a `DownloadController`
+- **WHEN** the hint presenter or a flash worker reads `frame.manifest`
+- **THEN** the frame SHALL expose `manifest` as a property shim over the
+  controller, exactly as `_handset_ports` shims `handset.ports`
+
+### Requirement: Worker threads never touch widgets except via wx.CallAfter
+
+Background worker threads (flash, batch-flash, BTF-flash, download, dry-run,
+diagnostics, port-poll, probe, update-check, manifest-fetch) SHALL NOT call any
+wx widget method directly. All widget mutation originating on a worker thread
+SHALL be marshalled onto the GUI thread via `wx.CallAfter` (or an equivalent
+frame helper such as `log_msg` / `set_progress` / `set_buttons` that itself uses
+`wx.CallAfter`). A worker SHALL also honor the `_closing` guard so a `wx.CallAfter`
+that lands after the frame begins tearing down does not touch destroyed widgets.
+
+#### Scenario: Per-row status update from a flash worker
+
+- **GIVEN** a batch flash worker thread flashing multiple ports
+- **WHEN** it updates a handset row's Status or Progress cell
+- **THEN** it SHALL do so through `wx.CallAfter(self._set_handset_status, …)` /
+  `wx.CallAfter(self._set_handset_progress, …)`
+- **AND** it SHALL NOT call `handset_list.SetItem` directly from the worker thread
+
+#### Scenario: Background task posts after the window is closing
+
+- **GIVEN** the update-check or manifest-fetch thread completes after the user
+  closed the window
+- **WHEN** its completion callback runs on the GUI thread
+- **THEN** the callback SHALL check `_closing` / frame validity before touching
+  the status bar or download button, as `_notify_update` and `_update_radio_info`
+  already do
+
+#### Scenario: Log and progress marshalling helpers
+
+- **GIVEN** the `FlashController` owns `log_msg` and `set_progress`
+- **WHEN** any worker appends a log line or updates the progress gauge
+- **THEN** those helpers SHALL wrap the widget call in `wx.CallAfter`
+- **AND** workers SHALL route all log/progress output through them rather than
+  touching `self.log` / `self.progress` directly
+
+### Requirement: Protocol-adjacent logic is headlessly testable
+
+Logic that is adjacent to the serial protocol or workflow decisions SHALL be
+structured so it can be exercised without a display and without live hardware:
+pure decision/formatting helpers SHALL be module-level functions (or take
+injectable dependencies), and GUI worker threads that drive the flash/dry-run/
+diagnostics protocol SHALL delegate the on-the-wire work to the driver functions
+(`flash_to_port` / `dry_run` / `run_diagnostics` / `probe_port`) that are testable
+against `mock_bootloader`, rather than hand-rolling `serial.Serial` inline. A
+change that touches worker threads together with serial I/O and live widgets SHALL
+pass the manual hardware checklist before merge.
+
+#### Scenario: Pure helper is unit-tested without wx or pyserial
+
+- **GIVEN** per-radio info formatting is extracted as
+  `format_radio_info(radio, firmware_version)`
+- **WHEN** the test suite runs in a headless / wx-less environment
+- **THEN** the helper SHALL be importable and unit-testable without constructing a
+  frame or opening a serial port, following the `enumerate_serial_ports` /
+  `compute_hint_state` precedent
+
+#### Scenario: Single-flash worker is coverable end-to-end via the mock bootloader
+
+- **GIVEN** the single-flash KDH, dry-run, and diagnostics paths currently
+  hand-roll `serial.Serial` + `send_command` inline and have no headless coverage
+- **WHEN** they are converged onto `fw.flash_to_port` / `fw.dry_run` /
+  `fw.run_diagnostics` (as the batch path already uses `driver.flash_to_port`)
+- **THEN** the GUI worker wrapper SHALL be exercisable end-to-end with
+  `mock_bootloader.patch_serial`, matching the existing `TestEndToEndFlashKDH`
+  driver-level tests
+
+#### Scenario: Serial-touching slice is gated by the hardware checklist
+
+- **GIVEN** the `gui_flash` slice moves worker threads that open serial ports and
+  update live widgets
+- **WHEN** the slice is prepared for merge
+- **THEN** the PR SHALL include the manual hardware-checklist results (single,
+  batch, BTF, dry-run, diagnostics on a real radio), per the PR #19 pattern
+- **AND** CI green alone SHALL NOT be sufficient to merge that slice

--- a/openspec/changes/decompose-gui-main-workers/tasks.md
+++ b/openspec/changes/decompose-gui-main-workers/tasks.md
@@ -1,0 +1,133 @@
+# Decompose gui_main Workers — Implementation Tasks
+
+Each slice is a self-contained PR. A slice MUST leave `python3 tests.py` green on
+its own and be mergeable independently. Slices land in order (1 → 2 → 3); the
+hardware-checklist gate applies only to the slice that touches serial (Slice 3).
+
+## Pre-flight (once, before Slice 1)
+
+- [ ] Confirm baseline green: `python3 tests.py`
+- [ ] Note the delegator idiom in `gui_handset.py` / `gui_columns.py` (frame
+      publishes the component, keeps same-named thin delegators + property shims)
+- [ ] Confirm no source behavior change is intended in any move-only commit
+
+---
+
+## Slice 1 — `gui_hints` (HintPresenter) — risk: low
+
+1. [ ] Create `gui_hints.py` with a guarded `import wx` (headless-importable),
+       mirroring the header/docstring style of `gui_handset.py`
+2. [ ] Add pure `format_radio_info(radio, firmware_version)` — move the string-
+       building out of `_format_radio_info`; no widget access
+3. [ ] Add `HintPresenter(frame)` owning `set_hint`, `compute_hint_state`,
+       `get_hint_copy`, and `on_state_change`; reach back through `frame` for
+       `hint_text`, `_get_selected_radio`, `_get_firmware_url_and_version`,
+       `_firmware_ready`, `_selected_handset_indices`, `_busy` / `_terminal_state`
+       / `_busy_state`, `font_size`
+4. [ ] In `gui_main.py`, construct `self.hints = HintPresenter(self)` in
+       `__init__` and replace the moved bodies with thin delegators keeping the
+       exact names: `_set_hint`, `_compute_hint_state`, `_get_hint_copy`,
+       `_format_radio_info`, `_on_state_change`
+5. [ ] Keep the `HINT_STATES` / `_RADIO_INFO_STATES` class attributes resolving to
+       the gui_workflow source of truth (referenced by tests + `retranslate_ui`)
+6. [ ] Verify unchanged call sites still resolve: `retranslate_ui`,
+       `HandsetController.on_check_changed` / `_probe_thread`,
+       `_update_workflow_gating`, `_update_radio_info`, every worker's
+       `wx.CallAfter` hint refresh
+7. [ ] Add headless test `TestRadioInfoFormatting` for `format_radio_info`
+       (skip-if-unimportable, per `TestHandsetPortEnumeration`)
+8. [ ] Run `python3 tests.py` — all green (existing `TestHintCopy`,
+       `TestWorkflowStateMachine` unchanged)
+9. [ ] Manual smoke (headed): launch, change radio / firmware / handset selection,
+       switch language — hint panel and per-radio info render correctly
+10. [ ] `CHANGELOG.md` entry; open PR "Extract hint presenter from gui_main (#NN)"
+
+---
+
+## Slice 2 — `gui_download` (DownloadController) — risk: medium (no hardware gate)
+
+1. [ ] Create `gui_download.py` with guarded `import wx`
+2. [ ] Add `DownloadController(frame)` owning the download worker
+       (`on_download`, `_download_thread`, `on_browse`), firmware discovery
+       (`_get_firmware_url_and_version`, `_update_radio_info`, `on_radio_changed`),
+       and the background tasks (`_fetch_manifest`, `_check_update`,
+       `_notify_update`, `_show_update_link`)
+3. [ ] Expose `frame.manifest` as a property shim over the controller (pattern:
+       `_handset_ports` → `handset.ports`) so hints/flash keep reading it
+4. [ ] Leave `_get_selected_radio` and `_driver_for` on the frame (shared with
+       handset/hints/flash) — do NOT move them into this controller
+5. [ ] Replace moved bodies with thin frame delegators keeping names: `on_download`,
+       `on_browse`, `on_radio_changed`, `_update_radio_info`,
+       `_get_firmware_url_and_version` (bound by gui_columns / read by hints+flash)
+6. [ ] Confirm all worker→widget updates stay on `wx.CallAfter` and the `_closing`
+       guards in `_notify_update` / `_update_radio_info` are preserved
+7. [ ] Keep the `_busy` interlock: download sets `_busy` / `_busy_state`
+       ("downloading") exactly as before so flashing can't start concurrently
+8. [ ] Add headless test: `_download_thread` scales progress to 80 % and sets
+       `_terminal_state` on success/failure using a fake `dl` (reuse
+       `TestDownloader` / `TestUpdater` seams; no `mock_bootloader`)
+9. [ ] Run `python3 tests.py` — all green
+10. [ ] Manual smoke (headed, network): pick a radio → Download → firmware lands
+       and path populates; simulate/observe update-available link
+11. [ ] `CHANGELOG.md` entry; open PR "Extract download + updater controller from
+       gui_main (#NN)"
+
+---
+
+## Slice 3 — `gui_flash` (FlashController) — risk: high (hardware-checklist gate)
+
+### Commit 3a — move-only (behavior preserved)
+
+1. [ ] Create `gui_flash.py` with guarded `import wx`
+2. [ ] Add `FlashController(frame)` owning `on_flash`, `_flash_thread`,
+       `_flash_thread_btf`, `_batch_flash_thread`, `_prompt_continue_batch`,
+       `on_dry_run`, `_dryrun_thread`, `on_diag`, `_diag_thread`,
+       `_offer_test_report`, `_offer_firmware_cleanup`, `log_msg`,
+       `set_progress`, `set_buttons`
+3. [ ] Leave `_is_permission_denied` and `_log_dialout_hint` on the frame (shared
+       with HandsetController's probe); leave `_get_selected_radio` /
+       `_driver_for` / `_get_firmware_url_and_version` on the frame
+4. [ ] Replace moved bodies with thin frame delegators keeping names: `on_flash`,
+       `on_dry_run`, `on_diag`, `log_msg`, `set_progress`, `set_buttons`
+5. [ ] Confirm the batch path still calls `frame._set_handset_status` /
+       `_set_handset_progress` / `_selected_handset_indices` and the gui_handset
+       `STATUS_*` constants — unchanged
+6. [ ] Verify no worker touches a widget except via `wx.CallAfter`; `_busy` /
+       `_terminal_state` transitions and the `set_buttons(True)` re-gating in
+       `finally` blocks are byte-for-byte preserved
+7. [ ] Run `python3 tests.py` — all green (`TestEndToEndFlashKDH`,
+       `TestEndToEndFlashBTF`, `TestBatchFlashRouting` unchanged at driver level)
+8. [ ] **HARDWARE CHECKLIST (gate — must pass before merge):** on a real radio,
+       verify single KDH flash, batch KDH flash across 2 ports (incl. one induced
+       failure → Continue/Stop prompt), BTF flash (RT-950 Pro), dry-run, and
+       diagnostics; confirm per-row Status/Progress, log output, permission-denied
+       (dialout) hint, and test-report + cleanup prompts all behave as before
+9. [ ] `CHANGELOG.md` entry; open PR "Extract flash/dry-run/diagnostics workers
+       from gui_main (#NN)" with the hardware-checklist results in the description
+
+### Commit 3b — driver convergence (closes headless-coverage gap)
+
+10. [ ] Replace the hand-rolled inline serial in `_flash_thread` (single-flash KDH)
+        with a call to `fw.flash_to_port(port, firmware, log_cb=…, progress_cb=…)`,
+        preserving log/progress/version-recording/test-report behavior
+11. [ ] Route the KDH branch of `_dryrun_thread` through `fw.dry_run` and
+        `_diag_thread` through `fw.run_diagnostics` (matching the batch path's use
+        of `driver.flash_to_port`)
+12. [ ] Add `mock_bootloader.patch_serial` tests for the GUI single-flash / dry-run
+        / diagnostics wrappers (mirror `_flash` in `TestEndToEndFlashKDH`)
+13. [ ] Run `python3 tests.py` — new wrapper tests green
+14. [ ] **HARDWARE CHECKLIST (gate again — behavior-adjacent):** re-verify single
+        flash, dry-run, diagnostics on a real radio
+15. [ ] `CHANGELOG.md` entry; open PR with hardware-checklist results
+
+---
+
+## Definition of done (whole change)
+
+- [ ] `gui_hints.py`, `gui_download.py`, `gui_flash.py` exist; `gui_main.py` is a
+      coordinator (~950 lines) with same-named delegators for every moved method
+- [ ] No user-facing behavior change; no changes to `radios.json` /
+      `firmware_manifest.json` / i18n catalogs
+- [ ] `python3 tests.py` green after each slice; new headless units added per slice
+- [ ] Slice 3 merged only after its hardware checklist passed (both commits)
+- [ ] Each slice shipped as its own squash-merged PR

--- a/openspec/changes/generalize-hardware-variants/design.md
+++ b/openspec/changes/generalize-hardware-variants/design.md
@@ -1,0 +1,205 @@
+# Design: generalize hardware variants
+
+## Context
+
+Two radio models today ship as non-interchangeable hardware variants behind a
+single vendor bundle URL:
+
+| Model | Variant entries (ids) | Distinguisher |
+| --- | --- | --- |
+| BTECH BF-F8HP Pro | `bf-f8hp-pro` (NRF), `bf-f8hp-pro-nrfb` (NRFB) | radio off → hold `8` on power-on → display shows NRF / NRFB |
+| Radtel RT-490 | `rt-490` (old PCB), `rt-490-new` (new PCB) | does it have channel-name editing? |
+
+Both are handled ad hoc: two sibling `radios.json` entries, each with a
+`firmware_filename_pattern` selecting its file from the shared bundle, and the
+identification procedure written only in free-text `notes`. PR #21 added a
+post-download guard (`select_firmware_file`) that *refuses to guess* but never
+*asks*. This change makes variant identification a first-class, translatable,
+UI-gated step.
+
+Hard constraint carried through every decision: **radio ids are a compatibility
+surface.** Released client binaries fetch `firmware_manifest.json` from `master`
+keyed by id, and every translation catalog keys per-radio strings as
+`radio.<id>.<field>`. Changing or removing an existing id silently breaks
+already-shipped installs.
+
+## Decision 1 — Schema: sibling entries linked by `variant_group` (chosen) vs a nested `variants` list
+
+### Chosen: keep sibling entries, add a `variant_group` linkage + a `variant_groups` block
+
+Member entries stay exactly as they are (own id, own `firmware_url`, own
+`firmware_filename_pattern`) and gain one field:
+
+```json
+{ "id": "bf-f8hp-pro", "variant_group": "bf-f8hp-pro-family", ... }
+{ "id": "bf-f8hp-pro-nrfb", "variant_group": "bf-f8hp-pro-family", ... }
+```
+
+A new top-level block describes each group and, crucially, maps each
+identification answer to a concrete member id:
+
+```json
+"variant_groups": {
+  "bf-f8hp-pro-family": {
+    "name": "BTECH BF-F8HP Pro",
+    "manufacturer": "BTECH",
+    "firmware_page": "https://baofengtech.com/product/bf-f8hp-pro/",
+    "question": "Which hardware version is your BF-F8HP Pro?",
+    "steps": "With the radio OFF, hold the 8 key while turning it on. The display shows NRF or NRFB.",
+    "options": [
+      { "radio_id": "bf-f8hp-pro",      "label": "Display shows NRF" },
+      { "radio_id": "bf-f8hp-pro-nrfb", "label": "Display shows NRFB" }
+    ]
+  }
+}
+```
+
+`question`/`steps` are English source (mirroring how `radios.json` holds English
+source for per-radio fields); `label` per option is English source too. The
+option order is the presentation order; `radio_id` is the concrete entry the app
+resolves to.
+
+**Why this wins:**
+
+- **Ids are preserved.** All four existing ids remain top-level entries, so
+  `firmware_manifest.json` keys and `radio.<id>.<field>` translation keys keep
+  resolving. This directly satisfies the "preserving existing ids matters"
+  constraint.
+- **Backward compatible by construction.** `variant_group` and
+  `variant_groups` are additive. A released client running old `radios.json`
+  simply doesn't see them and behaves exactly as today (two separate dropdown
+  rows), while still resolving firmware from the unchanged remote manifest. New
+  clients reading new `radios.json` get the walkthrough. No manifest migration.
+- **Minimal blast radius downstream.** `download_and_extract`,
+  `get_radio_firmware_info`, and the flash workers all still receive a concrete
+  radio id; only the *selection* layer (dropdown + `_get_selected_radio`) grows
+  group awareness. The safety guard from PR #21 stays untouched.
+
+### Alternative: per-radio nested `variants` list
+
+Collapse each family to one entry whose id is the model, with variants nested:
+
+```json
+{ "id": "bf-f8hp-pro", "variants": [
+    { "variant_id": "nrf",  "firmware_filename_pattern": "NRF_ONLY_*.kdhx" },
+    { "variant_id": "nrfb", "firmware_filename_pattern": "NRFB_ONLY_*.kdhx" } ] }
+```
+
+Conceptually cleaner, but it **breaks the compatibility surface**:
+
+- The `bf-f8hp-pro-nrfb` and `rt-490-new` ids disappear as top-level keys.
+  Released clients that look up `manifest["bf-f8hp-pro-nrfb"]` get nothing, and
+  the per-variant firmware would have to be re-keyed inside a restructured
+  manifest — a breaking manifest change that old clients can't read.
+- Translation keys `radio.bf-f8hp-pro-nrfb.*` / `radio.rt-490-new.*` orphan;
+  every catalog needs a coordinated re-key, and until then `t_radio_field`
+  falls back to English.
+- We'd have to invent an id scheme for nested variants anyway (`<id>#<variant>`)
+  to keep the manifest and translations addressable — which is just
+  `variant_group` linkage wearing a more disruptive costume.
+
+The nested model would be the right call for a *greenfield* schema. Given four
+ids already in the wild, the sibling-linkage model buys the same UX at zero
+compatibility cost.
+
+## Decision 2 — UX: where the picker lives and how "I don't know" is handled
+
+### When/where
+
+- **Dropdown collapses a group to one family row.** `FirmwareColumn` builds the
+  choice list from `frame.radios`; grouped members are replaced by a single
+  entry labelled by `variant_groups.<id>.name`. Ungrouped radios render as
+  today. `_get_selected_radio()` maps the selected row back to either a concrete
+  radio or an unresolved group.
+- **The walkthrough appears on selection, in the existing info surface.**
+  Selecting a family renders the group `question` + `steps` in the same
+  hint/info panel that already shows bootloader keys and notes
+  (`_format_radio_info` / `_set_hint`), plus one selectable option per variant
+  and an explicit "I'm not sure." This reuses the panel the user is already
+  reading while prepping the radio — no new modal on the happy path.
+- **Download is gated, not guessed.** While a family is selected but no variant
+  is resolved, the Download button is disabled and labelled to say identify
+  first (new `button.identify_first` key). This mirrors the existing
+  `_update_radio_info` pattern that already toggles the button between
+  "Download v…", "Download Latest", and "No Direct URL." Once a variant is
+  chosen, the flow proceeds identically to a normal single-variant radio,
+  including the existing untested-radio confirmation dialog in `on_download`.
+
+Rationale for selection-time (vs deferring the whole thing to the Download
+click): the per-radio info panel is *already* the place identification prose
+lives today, and gating the button is a pattern the frame already implements.
+Deferring to a download-time modal would duplicate the info the panel must show
+anyway and would leave the button in a misleading "ready" state.
+
+### "I'm not sure" → safe default = stop
+
+- Choosing "I'm not sure," or not answering, resolves to **no variant**.
+  Download stays disabled; the app surfaces the group's `firmware_page` as a
+  link ("Not sure? Confirm your hardware version here") so the user can check
+  before risking a brick. This is the safe default because the failure mode is
+  asymmetric: a wrong guess can permanently damage the receiver, whereas
+  stopping only costs the user a lookup.
+- The post-download `select_firmware_file` guard remains as a second line of
+  defense for the case where the user picked a variant but the vendor repacked
+  the bundle and the pattern no longer matches exactly one file.
+
+## Decision 3 — i18n of identification steps
+
+The existing mechanism: English source lives in `radios.json`; non-English
+catalogs override per-radio strings under `radio.<id>.<field>`, resolved by
+`t_radio_field(radio_id, field, fallback)` which falls back to the English
+source. `TestRadioStringTranslations` enforces that every translatable field of
+every radio has a key in all 7 non-English catalogs and that no value merely
+echoes the English source.
+
+Two string categories, two keying strategies:
+
+1. **Per-variant answer labels** ("Display shows NRF", "Has channel-name
+   editing") belong to a member radio, so they reuse `t_radio_field` with a new
+   field name **`variant_label`**, keyed `radio.<id>.variant_label`. Adding
+   `variant_label` to `TestRadioStringTranslations.TRANSLATABLE_FIELDS` makes
+   the *existing* completeness + no-echo tests cover them for free across all
+   languages.
+2. **Group-level question and steps** are shared across members, so they key off
+   the group, not any one radio. Add a documented sibling helper
+   **`t_variant_field(group_id, field, fallback)`** keyed
+   `variant_group.<group_id>.<field>` — a deliberate, minimal extension of the
+   `t_radio_field` pattern (same fallback-to-English-source behavior, different
+   namespace). A new test (mirroring `TestRadioStringTranslations`) enforces
+   completeness + no-echo for `variant_group.*.question` and
+   `variant_group.*.steps` in all 7 languages.
+
+Rationale: reusing `radio.<id>.variant_label` for labels keeps the highest-churn
+strings inside the already-enforced test with no new machinery; introducing one
+sibling helper for the two genuinely group-scoped strings is the smallest
+documented extension that keeps group strings addressable and testable. Both
+helpers fall back to the English source in `radios.json`, so a missing
+translation degrades to English rather than a raw key.
+
+## Decision 4 — Backward compatibility
+
+- **Old radios.json + remote manifest.** Released binaries embed their own
+  `radios.json`. Because member ids are unchanged and the manifest keeps its
+  current id-keyed shape, an old client keeps resolving firmware URLs and hashes
+  from the remote manifest exactly as before; it just shows the two variant rows
+  separately and relies on `notes` + the post-download guard (its current
+  behavior). Nothing regresses.
+- **New client + old cached manifest.** New selection logic only needs
+  `radios.json` (local) to build the walkthrough; the manifest is consulted only
+  after a concrete id is resolved, so a stale cached manifest is a non-issue.
+- **Migration keeps `notes` populated** for both groups (possibly trimmed of the
+  now-structured identification prose) so old clients that render `notes`
+  continue to show identification guidance.
+
+## Open questions
+
+- Should the walkthrough be inline in the info panel (chosen) or a modal at
+  download time for stronger "you must answer" enforcement? Inline is proposed;
+  revisit if usability testing shows users skip it.
+- Widget choice for the options (wx.RadioBox vs a compact dropdown) — left to
+  implementation; must remain RTL- and translation-safe like the rest of the
+  frame.
+- Whether to generalize `firmware_filename_pattern` selection to key off the
+  resolved variant option directly (removing per-member patterns) — deferred;
+  keeping per-member patterns preserves the PR #21 guard semantics unchanged.
+</content>

--- a/openspec/changes/generalize-hardware-variants/proposal.md
+++ b/openspec/changes/generalize-hardware-variants/proposal.md
@@ -1,0 +1,116 @@
+# Generalize hardware variants
+
+## Why
+
+Vendors ship a single firmware bundle (one URL) that contains multiple
+hardware-variant firmware files which are **not interchangeable** — flashing
+the wrong one can brick the radio. The app currently handles this ad hoc, and
+the only thing standing between a user and a bricked radio is whether they read
+a paragraph of free-text `notes`.
+
+Concrete evidence in the current tree:
+
+- **BF-F8HP Pro NRF/NRFB.** `radios.json` carries two sibling entries,
+  `bf-f8hp-pro` (`NRF_ONLY_*.kdhx`) and `bf-f8hp-pro-nrfb` (`NRFB_ONLY_*.kdhx`),
+  both pointing at the *same* `F8HPPRO-V53-Update-Bundle.zip`. The only
+  identification guidance — "with the radio OFF, hold the 8 key while turning it
+  on; the display shows NRF or NRFB" — lives inside the `notes` string
+  (`radios.json:15`, `:28`). PR #21 (`a460154`) added this split after
+  BaofengTech silently repacked the bundle into two files, which broke the
+  previous single-file download outright.
+- **Radtel RT-490 old/new PCB.** `rt-490` (old PCB, real `firmware_url`) vs
+  `rt-490-new` (new PCB, `firmware_url: null`). Identification — "If your RT-490
+  has channel name editing, you have the new PCB" — again lives only in `notes`
+  (`radios.json:67`, `:80`), and the new-PCB notes explicitly warn that wrong
+  firmware "will brick the radio."
+- **The guard added in PR #21 only fails safe, it doesn't guide.**
+  `firmware_download.select_firmware_file()` refuses to guess when a pattern
+  matches zero or multiple files (`firmware_download.py:291-328`), and
+  `TestFirmwareVariantSelection` locks that in. But the guard triggers *after*
+  download, and its remedy is a wall of text telling the user to "pick the radio
+  entry that matches your hardware version" — the app never actually asks which
+  hardware they have.
+
+So the identification knowledge exists, but it is (a) unstructured, (b) buried
+in prose the user may skip, and (c) invisible to the UI, which cannot gate on
+it. The goal is a first-class *variants* concept so the app **walks the user
+through** identifying their hardware before it selects firmware, instead of
+hoping they read the notes.
+
+## What Changes
+
+- **Add a variant-group concept to `radios.json`** (additive schema): sibling
+  radio entries that represent hardware variants of one physical model are
+  linked by a shared `variant_group` id, and a top-level `variant_groups`
+  block describes each group's display name, the identification question, the
+  ordered identification steps, and which member id each answer selects. Member
+  entries keep their existing ids, urls, and `firmware_filename_pattern`.
+  **Existing ids are preserved** (`bf-f8hp-pro`, `bf-f8hp-pro-nrfb`, `rt-490`,
+  `rt-490-new`) — see design.md for why this rules out a nested-`variants` list.
+- **Collapse grouped siblings into one dropdown row.** The firmware dropdown
+  shows a single family line per variant group (e.g. "BTECH BF-F8HP Pro")
+  instead of one row per variant. Selecting a family launches the
+  identification walkthrough rather than pre-selecting a variant. Ungrouped
+  radios are unaffected.
+  - *(Internal, not a compatibility surface, but behavior-changing:*
+    `_get_selected_radio()`'s dropdown-index→radio mapping and the
+    `gui_columns.FirmwareColumn` dropdown population must learn about groups.)*
+- **Add a variant-identification walkthrough.** When a family is selected, the
+  app presents the group's question and steps and offers one choice per variant
+  plus an explicit **"I'm not sure"**. Download stays disabled until a concrete
+  variant is chosen; choosing one resolves to the member radio id, and every
+  downstream step (manifest lookup, `download_and_extract`, flashing) runs
+  unchanged against that resolved id.
+- **Refuse to guess a variant.** The app SHALL NOT auto-pick a variant or fall
+  through to "the first one." The post-download `select_firmware_file` guard is
+  retained as defense in depth.
+- **Safe default for "I'm not sure."** Selecting "I'm not sure" (or leaving the
+  question unanswered) SHALL stop before download, keep Download disabled, and
+  surface a link to the group's `firmware_page` so the user can confirm their
+  hardware.
+- **Make identification steps translatable.** The question and steps are
+  translated through the existing `radio.<id>.<field>` / `t_radio_field`
+  machinery, extended with a documented sibling for group-level strings
+  (`variant_group.<group_id>.<field>`). Per-variant answer labels reuse
+  `t_radio_field` with a new `variant_label` field so they slot into the
+  existing translation-completeness test across all 7 non-English languages.
+- **Migrate both existing pairs** (BF-F8HP Pro, RT-490) onto the new structure,
+  moving the identification prose out of `notes` and into structured, translated
+  identification steps.
+- **No breaking change to the remote manifest.** `firmware_manifest.json` stays
+  keyed by the same radio ids; released clients keep resolving firmware exactly
+  as they do today.
+
+## Impact
+
+- **Affected spec (delta):** `firmware-selection` — new requirements for the
+  variant walkthrough, refusal to guess, unknown-variant safe default, and i18n
+  of identification steps.
+- **Affected code:**
+  - `radios.json` — additive `variant_group` field on member entries +
+    top-level `variant_groups` block; migrate BF-F8HP Pro and RT-490.
+  - `firmware_download.py` — `load_radios`/`get_radio_by_id` gain group-aware
+    helpers (`load_variant_groups`, `get_variant_group`, `resolve_variant`);
+    `select_firmware_file` guard unchanged.
+  - `i18n.py` — add documented `t_variant_field(group_id, field, fallback)`
+    keyed `variant_group.<group_id>.<field>`; `t_radio_field` gains a
+    `variant_label` field usage.
+  - `gui_columns.py` (`FirmwareColumn`) — collapse grouped siblings into one
+    family row.
+  - `gui_main.py` — `_get_selected_radio`, `on_radio_changed`,
+    `_update_radio_info`, `_format_radio_info`, `on_download` learn to render
+    the walkthrough, gate Download on a resolved variant, and honor the
+    "I'm not sure" safe default.
+  - `translations/*.json` (7 languages) — add
+    `variant_group.<group_id>.{question,steps}` and
+    `radio.<id>.variant_label` keys for both migrated groups.
+  - `tests.py` — extend `TestRadioDefinitions` (variant-group integrity),
+    `TestRadioStringTranslations` (new translatable fields), and add coverage
+    for `resolve_variant` / the unknown-variant safe default.
+- **Compatibility surfaces (must stay stable):**
+  - Radio **ids** — consumed by `firmware_manifest.json` keys and by
+    `radio.<id>.<field>` translation keys. Preserved.
+  - **Remote manifest** fetched from `master` by released clients. Unchanged
+    shape; old clients ignore the new radios.json fields.
+</content>
+</invoke>

--- a/openspec/changes/generalize-hardware-variants/specs/firmware-selection/spec.md
+++ b/openspec/changes/generalize-hardware-variants/specs/firmware-selection/spec.md
@@ -1,0 +1,109 @@
+# firmware-selection (delta)
+
+## ADDED Requirements
+
+### Requirement: Hardware-variant identification walkthrough
+
+When a selected radio belongs to a hardware-variant group (multiple
+non-interchangeable firmware files behind one model), the app SHALL walk the
+user through identifying their hardware version before any firmware is selected
+or downloaded, instead of relying on free-text notes.
+
+Variant groups SHALL be defined in `radios.json` such that member radio entries
+retain their existing ids and are linked by a shared `variant_group`, and each
+group declares an identification `question`, ordered identification `steps`, and
+an ordered set of options each mapping one answer to exactly one member radio id.
+
+#### Scenario: Selecting a variant group presents the identification question
+
+- **GIVEN** a radio dropdown that lists a variant group (e.g. "BTECH BF-F8HP Pro")
+  as a single family row
+- **WHEN** the user selects that family row
+- **THEN** the app SHALL display the group's identification question and steps in
+  the language currently active
+- **AND** SHALL offer one selectable option per variant plus an explicit
+  "I'm not sure" choice
+- **AND** SHALL keep the Download control disabled until a concrete variant is
+  chosen.
+
+#### Scenario: Choosing a variant resolves to that member and enables download
+
+- **GIVEN** a variant group is selected with its identification question shown
+- **WHEN** the user chooses one of the variant options
+- **THEN** the app SHALL resolve the selection to that option's member radio id
+- **AND** SHALL enable the Download control and proceed exactly as for a
+  single-variant radio (manifest lookup, download, extraction, and flashing all
+  operating on the resolved id).
+
+### Requirement: The app must not guess a hardware variant
+
+The app SHALL NOT auto-select a hardware variant, and SHALL NOT fall back to
+"the first matching file" when a bundle contains multiple non-interchangeable
+firmware files.
+
+#### Scenario: No variant chosen means no firmware selected
+
+- **GIVEN** a variant group is selected but no variant option has been chosen
+- **WHEN** the user attempts to download
+- **THEN** the app SHALL NOT begin a download
+- **AND** SHALL NOT select any firmware file on the user's behalf.
+
+#### Scenario: Post-download guard still refuses ambiguous bundles
+
+- **GIVEN** a resolved variant whose `firmware_filename_pattern` matches zero or
+  more than one file in the downloaded bundle (e.g. after a vendor repack)
+- **WHEN** extraction completes
+- **THEN** the app SHALL raise an error that names the files actually present and
+  SHALL NOT flash any of them.
+
+### Requirement: Unknown-variant safe default
+
+When the user cannot identify their hardware variant, the app SHALL fail safe by
+stopping before download rather than guessing, because flashing the wrong
+variant can permanently damage the radio.
+
+#### Scenario: "I'm not sure" stops and links to the vendor page
+
+- **GIVEN** a variant group is selected
+- **WHEN** the user chooses "I'm not sure" (or leaves the question unanswered)
+- **THEN** the app SHALL keep the Download control disabled
+- **AND** SHALL surface a link to the group's `firmware_page` so the user can
+  confirm their hardware version before proceeding.
+
+### Requirement: Translatable identification steps
+
+Variant identification strings SHALL be translatable through the existing
+per-radio translation mechanism (`radio.<id>.<field>` resolved by
+`t_radio_field`) or a documented extension of it, so identification guidance is
+presented in the user's language in all shipped locales.
+
+Per-variant answer labels SHALL be keyed `radio.<id>.variant_label` and covered
+by the existing per-radio translation-completeness enforcement. Group-level
+question and steps SHALL be keyed `variant_group.<group_id>.<field>` and resolved
+by a documented sibling helper that falls back to the English source in
+`radios.json`.
+
+#### Scenario: Identification question and steps render in the active language
+
+- **GIVEN** a non-English language is active and its catalog contains the group's
+  `variant_group.<group_id>.question` and `.steps` keys
+- **WHEN** the user selects that variant group
+- **THEN** the app SHALL display the translated question and steps
+- **AND** SHALL display each option using its translated
+  `radio.<id>.variant_label`.
+
+#### Scenario: Missing translation falls back to English source, never a raw key
+
+- **GIVEN** a language catalog is missing a variant identification key
+- **WHEN** that string is rendered
+- **THEN** the app SHALL fall back to the English source defined in `radios.json`
+  rather than showing the raw translation key.
+
+#### Scenario: Translation completeness is enforced across all shipped locales
+
+- **GIVEN** the test suite runs
+- **THEN** it SHALL assert that every `variant_label` and every group
+  `question`/`steps` string has a non-echoed translation in each of the 7
+  non-English catalogs, failing if any locale is missing a key or merely echoes
+  the English source.
+</content>

--- a/openspec/changes/generalize-hardware-variants/tasks.md
+++ b/openspec/changes/generalize-hardware-variants/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: generalize hardware variants
+
+Ordered so the test suite stays green after every numbered group. Data +
+helpers land before the UI consumes them; migration of live entries happens only
+once both the readers and the tests understand the new shape.
+
+## 1. Schema + test scaffolding (data model, no behavior change)
+
+- [ ] 1.1 Document the `variant_group` member field and top-level
+      `variant_groups` block (with `name`, `manufacturer`, `firmware_page`,
+      `question`, `steps`, `options[].radio_id`, `options[].label`) in a comment
+      in `radios.json` and in `openspec/project.md` domain notes.
+- [ ] 1.2 Add `TestRadioDefinitions` cases: every `variant_group` referenced by
+      a member exists in `variant_groups`; every group `option.radio_id`
+      resolves to a real, distinct radio id; group members all share the same
+      `variant_group`; option order is deterministic. (Passes vacuously until
+      groups are added.)
+- [ ] 1.3 Add a `TestVariantGroups` case class asserting each group has a
+      non-empty `question` and `steps`, at least two options, and a
+      `firmware_page`.
+
+## 2. Data helpers in firmware_download.py (pure, headless-testable)
+
+- [ ] 2.1 Add `load_variant_groups()` and `get_variant_group(group_id)` reading
+      the new `variant_groups` block (empty/None-safe when absent).
+- [ ] 2.2 Add `resolve_variant(group_id, radio_id)` → the concrete member radio
+      dict, and a `variant_members(group_id)` helper listing member ids in
+      option order. Keep `get_radio_by_id` and `select_firmware_file` unchanged.
+- [ ] 2.3 Unit-test the helpers, including the unknown / "not sure" path
+      (resolve returns None → callers must stop; assert no firmware id is
+      produced).
+
+## 3. i18n plumbing
+
+- [ ] 3.1 Add `t_variant_field(group_id, field, fallback)` to `i18n.py`, keyed
+      `variant_group.<group_id>.<field>`, falling back to the English source in
+      `variant_groups`. Document it next to `t_radio_field`.
+- [ ] 3.2 Add `variant_label` to
+      `TestRadioStringTranslations.TRANSLATABLE_FIELDS` (completeness + no-echo
+      now cover per-variant labels once labels exist).
+- [ ] 3.3 Add a translation-completeness test (mirroring
+      `TestRadioStringTranslations`) for `variant_group.<id>.question` and
+      `variant_group.<id>.steps` across all 7 non-English catalogs, rejecting
+      English echoes.
+- [ ] 3.4 Add UI string keys to `translations/en.json`:
+      `button.identify_first`, `info.variant_question`, `info.variant_steps`,
+      `info.variant_not_sure`, `info.variant_confirm_link`.
+
+## 4. Migrate the BF-F8HP Pro group
+
+- [ ] 4.1 Add `variant_group: "bf-f8hp-pro-family"` to `bf-f8hp-pro` and
+      `bf-f8hp-pro-nrfb`; add the `bf-f8hp-pro-family` entry to `variant_groups`
+      (question/steps from the current NRF/NRFB notes; options → the two ids
+      with labels "Display shows NRF" / "Display shows NRFB"). Trim the
+      duplicated identification prose from each member's `notes` but keep the
+      remaining cabling/pressure guidance.
+- [ ] 4.2 Add `radio.bf-f8hp-pro.variant_label`,
+      `radio.bf-f8hp-pro-nrfb.variant_label`, and
+      `variant_group.bf-f8hp-pro-family.{question,steps}` to all 7 non-English
+      catalogs (real translations, not English echoes). Reuse the existing
+      NRF/NRFB translated prose already in each catalog as the source.
+- [ ] 4.3 Run the suite — schema + translation tests must pass with the group in
+      place; ids unchanged so `TestFirmwareVariantSelection` still passes.
+
+## 5. Migrate the RT-490 group
+
+- [ ] 5.1 Add `variant_group: "rt-490-family"` to `rt-490` and `rt-490-new`; add
+      the `rt-490-family` group (question "Which PCB revision?", steps about
+      channel-name editing; options → `rt-490` "No channel-name editing (old
+      PCB)" / `rt-490-new` "Has channel-name editing (new PCB)"). Keep
+      `rt-490-new`'s `firmware_url: null` behavior intact.
+- [ ] 5.2 Add the matching `variant_label` and
+      `variant_group.rt-490-family.{question,steps}` keys to all 7 catalogs.
+- [ ] 5.3 Run the suite green.
+
+## 6. Selection layer (gui_columns + gui_main)
+
+- [ ] 6.1 `gui_columns.FirmwareColumn`: build the dropdown so each variant group
+      contributes exactly one family row (label = translated group `name`);
+      ungrouped radios render as today. Record the row→(radio | group) mapping.
+- [ ] 6.2 `gui_main._get_selected_radio()`: return the concrete radio for
+      ungrouped rows and for a group whose variant is already resolved; return a
+      sentinel/None (with the group) when a family row is selected but
+      unresolved.
+- [ ] 6.3 `_update_radio_info()` / `_format_radio_info()`: when an unresolved
+      group is selected, render the translated `question` + `steps` + one option
+      per variant + "I'm not sure", and set the Download button disabled with the
+      `button.identify_first` label. Reuse `t_variant_field` and the
+      `variant_label` lookups.
+- [ ] 6.4 Wire the option control so choosing a variant resolves the group to
+      that member id and re-runs `_update_radio_info` (Download re-enables and
+      shows the normal version label); choosing "I'm not sure" keeps Download
+      disabled and shows the `firmware_page` confirm link.
+
+## 7. Download/flash gating
+
+- [ ] 7.1 `on_download`: guard that a group selection has a resolved variant
+      before proceeding; otherwise no-op (button should already be disabled —
+      belt and suspenders). Everything after resolution is unchanged and runs on
+      the concrete id (untested dialog, `download_and_extract`, hashing, flash).
+- [ ] 7.2 Confirm the post-download `select_firmware_file` guard still fires for
+      repack/pattern-mismatch cases (regression check, no code change expected).
+
+## 8. Tests + docs closeout
+
+- [ ] 8.1 Add GUI-level (or headless helper) tests: selecting a family disables
+      Download; resolving a variant enables it; "I'm not sure" keeps it disabled
+      and exposes the confirm link.
+- [ ] 8.2 Full suite green in all 7 languages; update `CHANGELOG.md` and any
+      `USAGE.md` note about picking your hardware variant.
+- [ ] 8.3 Verify a simulated old-client path: unchanged remote manifest keys
+      still resolve for `bf-f8hp-pro`, `bf-f8hp-pro-nrfb`, `rt-490`,
+      `rt-490-new` (compatibility-surface assertion).
+</content>

--- a/openspec/changes/one-click-test-reports/design.md
+++ b/openspec/changes/one-click-test-reports/design.md
@@ -1,0 +1,130 @@
+# Design: One-Click Test Reports
+
+## When to prompt
+
+Offer after **every** terminal flash outcome — success and failure alike —
+same as today (`_offer_test_report` is already called from both the
+success path and the `except` block in `_flash_thread` and
+`_flash_thread_btf`). Failures on a `tested: false` radio are high-signal:
+they either confirm the radio needs real work, or (if the failure was
+transient — wrong port, cable) get filtered out by the reporter themselves
+before submitting, since they see the full body and can just hit Skip.
+
+The offer is gated by nag suppression (below), not by success/failure —
+that keeps the one behavior change (suppression) orthogonal to an existing,
+already-shipped behavior (offer on both outcomes) rather than bundling a
+second, unrelated decision into this change.
+
+## How not to nag
+
+Key the suppression on **(radio id, firmware version)**, the same grain
+`record_flash` already uses for `last_flashed`. Rationale: a version bump is
+exactly the case where a fresh report is still valuable (new firmware can
+regress a previously-working radio), so suppression must not key on radio
+id alone.
+
+State shape, alongside the existing `last_flashed` block in
+`~/.flintwave-flash/state.json`:
+
+```json
+{
+  "last_flashed": { "...": "..." },
+  "test_reports": {
+    "<radio_id>": {
+      "<version>": "submitted" | "skipped"
+    }
+  }
+}
+```
+
+- `"submitted"` is written when the user clicks Submit (browser opens).
+- `"skipped"` is written only when the user explicitly checks "don't ask
+  again for this radio+firmware" and then dismisses — a plain Skip (the
+  existing button, unchanged) does not suppress future offers, since a
+  reflexive Skip right after a failure is not the same signal as a
+  considered "I don't want to be asked about this again."
+- Missing version (e.g. `record_flash` didn't detect one from the
+  filename) falls back to keying on radio id alone with a sentinel
+  version string `"unknown"`, so suppression still degrades gracefully
+  instead of crashing or never suppressing.
+- Two new pure functions in `firmware_manifest.py`, mirroring
+  `record_flash`/`get_last_flashed`:
+  - `mark_test_report(radio_id, version, status)` — status is
+    `"submitted"` or `"skipped"`.
+  - `get_test_report_status(radio_id, version)` — returns the stored
+    status or `None`.
+- `_offer_test_report` in `gui_main.py` checks
+  `get_test_report_status(radio["id"], file_version)` before calling
+  `show_test_report_dialog`; if already `"submitted"` or `"skipped"`, it
+  skips the dialog entirely (no interruption at all, not even a
+  lighter-weight one — that's the point).
+
+## Privacy: what's in the prefilled log
+
+Unchanged from today's behavior, called out explicitly here because the
+change makes the report fire more habitually (once per radio+version
+instead of being skippable-into-oblivion by fatigue):
+
+- Body includes: radio name, firmware filename (basename only — no local
+  path), success/failure, OS name + release, Python version, error message
+  string (if failure), and the last 2000 characters of the in-app log
+  panel.
+- The log panel only ever contains protocol step names, chunk-progress
+  lines, and error text produced by this app's own `log_msg` calls — no
+  filesystem paths beyond the firmware basename, no serial port contents
+  beyond protocol framing bytes rendered as hex/text by existing log
+  lines, no credentials (the app has none to leak).
+- Nothing is transmitted automatically. `wx.LaunchDefaultBrowser` opens a
+  normal `github.com/.../issues/new?...` URL; the user sees the full
+  rendered issue body in GitHub's own compose form (and in the in-app
+  preview `TextCtrl` before that) and must click GitHub's own "Submit new
+  issue" — the same two-step confirmation as today, unchanged by this
+  proposal.
+- The "don't ask again" checkbox state and the `submitted`/`skipped`
+  status are the only new data written to disk, and they never leave the
+  machine — `state.json` is local-only, same as `last_flashed`.
+
+## URL length
+
+GitHub's `issues/new` prefill has a practical URL-length ceiling (browsers
+commonly cap around 8k characters; GitHub itself has been observed
+truncating well past that). Current budget with the existing 2000-char log
+truncation:
+
+- Fixed prose (title, labels, radio/firmware/result/OS/python lines,
+  headers): well under 500 chars even in the most verbose translated
+  locale.
+- Log payload: capped at 2000 raw characters, but `urllib.parse.urlencode`
+  percent-encodes newlines and other bytes, which can expand the encoded
+  length up to ~3x in the worst case (e.g. a log full of control
+  characters) — so 2000 raw chars can become ~6000 encoded chars.
+- Total worst case (~6500 encoded chars) stays under the ~8k practical
+  ceiling but not with much headroom once title/labels are added.
+
+Decision: keep the 2000-char raw cap (no change), but add a test that
+encodes a worst-case-density log (e.g. all newlines, which encode 3 bytes
+each as `%0A`) and asserts the final encoded URL stays under a documented
+budget (8000 chars), so a future change to the log format or truncation
+length can't silently blow past what browsers/GitHub will accept.
+
+## Maintainer side: mapping reports to `tested` flips
+
+No new tooling in this change (kept out of scope — this proposal is
+app-side only). The existing shape already carries what's needed:
+
+- Every report is labeled `test-report` (unchanged) — a maintainer can
+  filter the issue tracker on that label.
+- The body's first line is always `Radio: {radio_name}` and, when present,
+  an error line — both already exact-matchable against `radios.json`
+  `name` fields.
+- Convention documented here (not enforced in code): when a maintainer
+  reads a `test-report` issue reporting **success** on a radio whose
+  `radios.json` entry is `tested: false`, flipping that entry to
+  `tested: true` and closing the issue with a reference to it (as already
+  done for issue #20, see `CHANGELOG.md` v26.07.0) is the expected
+  workflow. A **failure** report on an already-`tested: true` entry is a
+  regression bug report, not a flag flip.
+- Future, out-of-scope idea (noted so it isn't lost, not built here): an
+  issue template or a small script that greps open `test-report` issues
+  against `radios.json` ids to flag stale `tested: false` entries with an
+  open confirming report.

--- a/openspec/changes/one-click-test-reports/proposal.md
+++ b/openspec/changes/one-click-test-reports/proposal.md
@@ -1,0 +1,80 @@
+# One-Click Test Reports
+
+## Why
+
+14 of the entries in `radios.json` are `tested: false`, including the entire
+RT-950 Pro BTF protocol path, which has never been confirmed on real
+hardware. `tested` flags only ever flip from a community member filing a
+GitHub issue after a real flash. The app already builds and offers that
+report — `show_test_report_dialog()` in `gui_dialogs.py` fires from
+`_offer_test_report()` after every flash attempt in `gui_main.py`
+(`_flash_thread` and `_flash_thread_btf`), prefilled with radio, firmware
+file, result, OS, Python version, and a truncated log, opening
+`github.com/.../issues/new` with `title`/`body`/`labels=test-report` query
+params. Issue #20 (BF-F8HP Pro NRF confirmation, see `CHANGELOG.md` v26.07.0)
+proves the mechanism works end-to-end.
+
+But the mechanism has three gaps that blunt it as a steady source of
+confirmations:
+
+- **It nags.** The dialog fires unconditionally on every flash, success or
+  failure, with no memory. Flash the same radio+firmware twice (e.g. batch
+  flashing a stack of identical handsets) and the identical prompt appears
+  every time — the classic path to users reflexively hitting Skip.
+- **It isn't testable as a unit.** The URL and report-body construction
+  live inline inside `show_test_report_dialog()`, a function that also
+  constructs `wx.Dialog` widgets. `tests.py`'s `TestReportURLs` and
+  `TestReportGeneration` re-derive the same logic by hand rather than
+  calling the real code, so a change to the real body/URL builder isn't
+  actually guarded by those tests.
+- **There's no maintainer-side convention** connecting an incoming
+  `test-report` issue back to a specific `radios.json` entry's `tested`
+  flag, so triage is manual guesswork every time.
+
+Failures are arguably the more valuable report (a failure on an untested
+radio is exactly the signal maintainers need), so the offer should not be
+success-only, but it does need to stop nagging once a given radio+firmware
+combination has already been reported — or explicitly skipped.
+
+## What Changes
+
+- Extract report body and GitHub issue URL construction out of
+  `show_test_report_dialog()` into pure, unit-testable functions (no wx
+  dependency), so `tests.py` exercises the real code path instead of a
+  hand-rolled copy.
+- Add nag suppression: once a report has been submitted (or explicitly
+  skipped) for a given radio id + firmware version, don't offer again for
+  that same combination. Remembered in `~/.flintwave-flash/state.json`
+  alongside the existing `last_flashed` record, via `firmware_manifest.py`'s
+  `_load_state`/`_save_state`.
+- Keep offering after both success and failure (unchanged), but gate the
+  offer on the new suppression check.
+- Add an explicit "don't ask again for this radio+firmware" affordance
+  distinct from the existing per-instance Skip, and reflect this choice in
+  the dialog/i18n copy.
+- Document (in `design.md`, not code) a lightweight maintainer-side
+  convention — the existing `test-report` label plus a `radio: <id>` line
+  already present in the prefilled body — so a triaged report maps
+  unambiguously to a `radios.json` `tested` flip.
+- Add/extend i18n keys for the new "don't ask again" affordance across all
+  8 catalogs (`translations/en.json` plus the 7 translated catalogs
+  enumerated in `tests.py`'s `TestRadioStringTranslations.REQUIRED_LANGS`).
+- Add tests: URL-length safety margin for the prefilled log payload, pure
+  function coverage for body/URL construction, and nag-suppression state
+  transitions (first flash prompts, repeat flash of the same
+  radio+firmware doesn't, a different firmware version on the same radio
+  prompts again).
+
+No changes to `radios.json` `tested` values themselves — those only change
+when a maintainer reviews and merges an actual community report.
+
+## Impact
+
+- Affected code: `gui_dialogs.py` (report dialog + new pure helpers),
+  `gui_main.py` (`_offer_test_report` call sites in `_flash_thread` and
+  `_flash_thread_btf`), `firmware_manifest.py` (new state key alongside
+  `last_flashed`), `translations/*.json` (8 catalogs), `tests.py`.
+- Affected specs: new capability `test-reporting`.
+- No changes to the serial/flash protocol, `radios.json` data, or the
+  GitHub issue submission mechanism itself (still a browser-opened
+  `issues/new` URL — no network calls added, no telemetry).

--- a/openspec/changes/one-click-test-reports/specs/test-reporting/spec.md
+++ b/openspec/changes/one-click-test-reports/specs/test-reporting/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Post-flash report offer
+The system SHALL offer to file a community test report after every
+terminal flash outcome (success or failure), unless suppressed per the
+nag-suppression requirement below.
+
+#### Scenario: Successful flash on a never-reported radio+firmware
+- **WHEN** a flash completes successfully for a radio id and firmware
+  version that have no prior `submitted` or `skipped` record in
+  `state.json`
+- **THEN** the app shows the test report dialog prefilled for a success
+  report
+
+#### Scenario: Failed flash on a never-reported radio+firmware
+- **WHEN** a flash fails (any exception during the flash thread) for a
+  radio id and firmware version that have no prior `submitted` or
+  `skipped` record in `state.json`
+- **THEN** the app shows the test report dialog prefilled for a failure
+  report, including the error message
+
+### Requirement: Prefilled report content
+The system SHALL prefill the report title and body from data already
+available in-app, and SHALL construct the GitHub issue URL via a pure
+function independent of any GUI widget so it is unit-testable without a
+display.
+
+#### Scenario: Report body fields
+- **WHEN** the report body is built for a flash outcome
+- **THEN** it includes, in order: radio name, firmware filename (basename
+  only), result (SUCCESS or FAILED), OS name and release, Python version,
+  the error message if the flash failed, and (if a log was captured) the
+  last 2000 characters of the in-app log under a log header
+
+#### Scenario: URL stays within a safe length budget
+- **WHEN** the report body includes a 2000-character log tail composed
+  entirely of characters that expand under percent-encoding (e.g.
+  newlines)
+- **THEN** the fully encoded `issues/new` URL (title + body + labels)
+  SHALL remain under 8000 characters
+
+#### Scenario: Special characters are safely escaped
+- **WHEN** the radio name, firmware filename, or log content contains
+  characters with special meaning in a URL or HTML context (`<`, `>`,
+  `"`, `&`)
+- **THEN** the constructed URL SHALL NOT contain those raw characters
+  unescaped
+
+### Requirement: Nag suppression
+The system SHALL remember, per radio id and firmware version, whether a
+report was already submitted or explicitly skipped, and SHALL NOT offer
+the report dialog again for that same combination.
+
+#### Scenario: Repeat flash of the same radio+firmware after submitting
+- **WHEN** a report was previously submitted for a given radio id and
+  firmware version
+- **AND** the same radio id and firmware version is flashed again
+- **THEN** the app does not show the report dialog
+
+#### Scenario: Repeat flash after explicit "don't ask again"
+- **WHEN** the user checked "don't ask again for this radio+firmware" and
+  dismissed the dialog for a given radio id and firmware version
+- **AND** the same radio id and firmware version is flashed again
+- **THEN** the app does not show the report dialog
+
+#### Scenario: Plain Skip does not suppress
+- **WHEN** the user dismisses the report dialog via the existing Skip
+  button without checking "don't ask again"
+- **AND** the same radio id and firmware version is flashed again
+- **THEN** the app shows the report dialog again
+
+#### Scenario: New firmware version on a previously-reported radio
+- **WHEN** a report was previously submitted or suppressed for radio id
+  `X` at firmware version `1.0`
+- **AND** radio id `X` is flashed with firmware version `2.0`
+- **THEN** the app shows the report dialog for the new version
+
+#### Scenario: Unknown firmware version degrades gracefully
+- **WHEN** the firmware version cannot be determined from the filename
+- **THEN** nag suppression keys on radio id alone using a fallback
+  version sentinel, and does not raise an error
+
+### Requirement: Report content privacy visibility
+The system SHALL show the user the complete, final prefilled report body
+before any data leaves the machine, and SHALL NOT transmit report data
+automatically.
+
+#### Scenario: User reviews before submitting
+- **WHEN** the report dialog is shown
+- **THEN** the full prefilled body is displayed in an editable, readable
+  text control before the user can submit
+
+#### Scenario: Submission requires explicit user action in the browser
+- **WHEN** the user clicks Submit in the report dialog
+- **THEN** the app opens the prefilled GitHub issue page in the user's
+  default browser and does not itself send any network request
+  containing report data; final submission still requires the user to
+  click GitHub's own submit control

--- a/openspec/changes/one-click-test-reports/tasks.md
+++ b/openspec/changes/one-click-test-reports/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: One-Click Test Reports
+
+## 1. Extract pure report-construction functions
+
+- [ ] 1.1 In `gui_dialogs.py`, extract the body-building logic currently
+      inline in `show_test_report_dialog()` into a standalone function,
+      e.g. `build_report_body(radio_name, firmware_path, success,
+      error_msg, log_content)` — no `wx` references, returns a plain
+      string.
+- [ ] 1.2 Extract the subject/title construction into a standalone
+      function, e.g. `build_report_subject(radio_name, success)`.
+- [ ] 1.3 Extract the GitHub issue URL construction into a standalone
+      function, e.g. `build_report_url(title, body)`, returning the full
+      `https://github.com/.../issues/new?...` string.
+- [ ] 1.4 Update `show_test_report_dialog()` to call these three
+      functions instead of inlining the logic, keeping its own scope to
+      widget construction and layout.
+
+## 2. Nag-suppression state
+
+- [ ] 2.1 In `firmware_manifest.py`, add `mark_test_report(radio_id,
+      version, status)` writing into a new top-level `test_reports` block
+      in state (`state["test_reports"][radio_id][version] = status`),
+      following the same load/mutate/`_save_state` pattern as
+      `record_flash`.
+- [ ] 2.2 Add `get_test_report_status(radio_id, version)` returning the
+      stored status string or `None`, mirroring `get_last_flashed`.
+- [ ] 2.3 Define and use a fallback version sentinel (e.g. `"unknown"`)
+      when `file_version` is falsy, in both the mark and get paths, so
+      suppression still works for firmware whose version can't be parsed
+      from the filename.
+
+## 3. Wire suppression into the flash-completion path
+
+- [ ] 3.1 In `gui_main.py`, before calling `show_test_report_dialog` from
+      `_offer_test_report`, check `fm.get_test_report_status(radio["id"],
+      file_version)`; if it is `"submitted"` or `"skipped"`, return
+      without showing the dialog.
+- [ ] 3.2 Thread `file_version` (already computed earlier in
+      `_flash_thread`/`_flash_thread_btf` via
+      `fv.extract_version_from_filename`) through to
+      `_offer_test_report` so the same value used for `record_flash` is
+      used for suppression lookups — avoid re-deriving it twice.
+- [ ] 3.3 Confirm both call sites (`_flash_thread` success/failure,
+      `_flash_thread_btf` success/failure) pass the radio dict and
+      version through consistently.
+
+## 4. "Don't ask again" affordance in the dialog
+
+- [ ] 4.1 Add a `wx.CheckBox` to the report dialog, unchecked by default,
+      labeled via a new i18n key (see section 6).
+- [ ] 4.2 On Submit: always call `mark_test_report(radio_id, version,
+      "submitted")` regardless of the checkbox (a submitted report always
+      suppresses future offers for that combination).
+- [ ] 4.3 On Skip: call `mark_test_report(radio_id, version, "skipped")`
+      only if the checkbox is checked; otherwise leave state untouched so
+      a plain Skip keeps prompting on future flashes.
+- [ ] 4.4 Pass `radio_id` and `version` into `show_test_report_dialog` (it
+      currently takes `radio_name`, not the id) so it can call
+      `mark_test_report` directly, or return the checkbox/button outcome
+      to the caller for `_offer_test_report` to persist — pick whichever
+      keeps `gui_dialogs.py` free of a `firmware_manifest` import if that
+      matters for the existing module layering (check current imports
+      before deciding).
+
+## 5. URL length safety
+
+- [ ] 5.1 Add a test that builds a worst-case log tail (2000 characters,
+      all newlines or another maximally-expanding character) through
+      `build_report_body` + `build_report_url` and asserts the resulting
+      URL length stays under 8000 characters.
+- [ ] 5.2 If the worst case exceeds budget, reduce the raw log truncation
+      length (currently 2000 chars in `show_test_report_dialog`, now
+      relocated into `build_report_body`) until it fits, and note the new
+      constant.
+
+## 6. i18n keys (all 8 catalogs: `en` plus the 7 in
+   `TestRadioStringTranslations.REQUIRED_LANGS` — `zh-CN`, `fr`, `de`,
+   `it`, `es`, `ar`, `ru`)
+
+- [ ] 6.1 Add `dialog.report.dont_ask_again` ("Don't ask again for this
+      radio and firmware version" or equivalent) to `translations/en.json`.
+- [ ] 6.2 Add the same key, properly translated (not English-echoed), to
+      `translations/zh-CN.json`, `fr.json`, `de.json`, `it.json`,
+      `es.json`, `ar.json`, `ru.json`.
+- [ ] 6.3 Run/extend `tests.py`'s translation-completeness checks (pattern
+      matches `TestRadioStringTranslations`) to also cover
+      `dialog.report.*` keys across all 7 non-English catalogs, catching
+      both missing keys and English-echoed values.
+
+## 7. Tests
+
+- [ ] 7.1 Update `TestReportURLs` and `TestReportGeneration` in
+      `tests.py` to call the real `build_report_body` /
+      `build_report_subject` / `build_report_url` functions from
+      `gui_dialogs` instead of re-deriving the logic inline.
+- [ ] 7.2 Add tests for `mark_test_report` / `get_test_report_status` in
+      `firmware_manifest.py`: fresh state returns `None`; marking
+      `"submitted"` then querying returns `"submitted"`; a different
+      version for the same radio id returns `None`; missing/falsy version
+      uses the fallback sentinel consistently between mark and get.
+- [ ] 7.3 Add a test for the URL length budget (see 5.1) as a permanent
+      regression guard.
+- [ ] 7.4 Add a GUI-level (or thin integration) test asserting
+      `_offer_test_report` does not invoke `show_test_report_dialog` when
+      `get_test_report_status` already returns a non-`None` value for the
+      given radio+version — mock/monkeypatch the dialog call the way
+      existing GUI tests in `tests.py` skip/stub headless widget calls.
+
+## 8. Docs
+
+- [ ] 8.1 Add a `CHANGELOG.md` entry under an "Unreleased" or next-version
+      section once implemented (not part of this proposal's scope to
+      write the entry now, but flag it so release notes aren't skipped).

--- a/openspec/changes/pin-firmware-hashes/proposal.md
+++ b/openspec/changes/pin-firmware-hashes/proposal.md
@@ -1,0 +1,36 @@
+# Pin Firmware Hashes — Proposal
+
+## Why
+
+Firmware vendors (BaofengTech, Radtel) silently repack bundles at unchanged URLs without updating file names or version strings. On 2026-07-10, BaofengTech repacked a bundle, breaking downloads for a week before detection. Null hashes in `firmware_manifest.json` are blind spots — the downloader silently accepts any repacked bundle, whether intentional or compromised.
+
+**Pinning is also a safety surface for old clients**: released versions fetch the manifest remotely from master, so pinning hashes means:
+- Any vendor repack requires a manifest update to restore functionality
+- Users see a clear error rather than silently using unexpected firmware
+- Old clients (e.g., v26.05) still benefit if a pin catches a repack after a later version is released
+
+Treating firmware bundles as immutable (via hash verification) is standard practice in package managers, OS vendors, and deployment tooling. The infrastructure to verify is already in place (`firmware_download.py` lines 268-282); only the pinned hashes are missing.
+
+## What Changes
+
+1. **Manifest**: Add SHA-256 hashes for all firmware entries with non-null URLs
+   - `uv-25-pro`: download bundle, verify contents, record hash
+   - `rt-470`: download bundle, verify contents, record hash
+   - `rt-490`: download bundle, verify contents, record hash
+   - `bf-f8hp-pro` and `bf-f8hp-pro-nrfb`: already pinned ✓
+
+2. **Tests**: Add assertion that every manifest entry with a non-null `firmware_url` MUST have a non-null `firmware_sha256`
+   - Prevents future entries from shipping unpinned
+
+3. **Specification**: Document that firmware bundles MUST be verified against pinned hashes, with actionable error messages on mismatch
+
+## Impact
+
+- **Functional**: No user-facing change; downloads are already verified against hashes if present. Adds verification where it was missing.
+- **Correctness**: Detects silent repacks (the exact incident that occurred 2026-07-10).
+- **Backwards compatible**: Existing verified downloads (bf-f8hp-pro entries) unchanged. Unverified downloads (uv-25-pro, rt-470, rt-490) become verified.
+- **Future-proofing**: Test gate ensures new entries can't ship unpinned.
+
+---
+
+**Related incident**: BaofengTech bundle repack 2026-07-10; undetected for 7 days despite null hashes in manifest.

--- a/openspec/changes/pin-firmware-hashes/specs/firmware-integrity/spec.md
+++ b/openspec/changes/pin-firmware-hashes/specs/firmware-integrity/spec.md
@@ -1,0 +1,62 @@
+# firmware-integrity — Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Firmware bundles SHALL be verified against pinned SHA-256 hashes
+
+Every `firmware_manifest.json` entry with a non-null `firmware_url` SHALL have
+a non-null `firmware_sha256`. Before extracting a downloaded bundle, the
+downloader SHALL compute the archive's SHA-256 and compare it to the pinned
+value; on mismatch it SHALL delete the file and refuse to extract.
+
+Rationale: vendors silently repack bundles at unchanged URLs (2026-07-10
+BaofengTech incident — clients with null hashes accepted the new bundle
+silently and broke for a week). Hash verification is the only reliable
+detection for repacks or tampering; firmware selection is safety-critical.
+
+#### Scenario: Normal download with pinned hash
+
+- **GIVEN** a manifest entry (e.g. `uv-25-pro`) with a pinned `firmware_sha256`
+- **WHEN** the user downloads firmware for that radio
+- **THEN** the bundle's computed SHA-256 SHALL be compared to the pinned value
+- **AND** extraction SHALL proceed only on an exact match, with no user-visible
+  friction on the happy path
+
+#### Scenario: Vendor repacks the bundle at an unchanged URL
+
+- **GIVEN** a manifest entry with a pinned hash
+- **WHEN** the vendor replaces the bundle content at the same URL
+- **THEN** the downloader SHALL detect the mismatch, delete the downloaded
+  file, and raise an error stating expected and actual hashes separately with
+  likely causes (repack, corruption, tampering)
+- **AND** the user SHALL be blocked from flashing until a human re-verifies
+  the new bundle and updates the manifest pin
+
+#### Scenario: Corrupted download
+
+- **GIVEN** a manifest entry with a pinned hash
+- **WHEN** the download is corrupted in transit
+- **THEN** the mismatch SHALL be reported the same way, the stale file SHALL
+  be deleted, and a retry SHALL be possible
+
+### Requirement: The test suite SHALL block unpinned manifest entries
+
+A test SHALL assert that every manifest entry with a non-null `firmware_url`
+has a non-null `firmware_sha256`, so future entries cannot ship unpinned.
+
+#### Scenario: New entry added without a hash
+
+- **GIVEN** a developer adds a manifest entry with a `firmware_url` and a null
+  `firmware_sha256`
+- **WHEN** the test suite runs (locally or in CI)
+- **THEN** the manifest-schema test SHALL fail naming the offending radio id,
+  blocking the PR until the bundle is downloaded, verified, and pinned
+
+## Notes
+
+- Currently pinned: `bf-f8hp-pro`, `bf-f8hp-pro-nrfb` (same bundle). Unpinned
+  blind spots: `uv-25-pro`, `rt-470`, `rt-490`. `rt-490-new` has a null URL —
+  nothing to pin.
+- Out of scope: changing firmware URLs; the Radtel live-scraper's null hashes
+  (separate decision); firmware-file content validation (owned by
+  `select_firmware_file()` per the firmware-selection spec).

--- a/openspec/changes/pin-firmware-hashes/tasks.md
+++ b/openspec/changes/pin-firmware-hashes/tasks.md
@@ -1,0 +1,75 @@
+# Pin Firmware Hashes — Implementation Tasks
+
+## Pre-flight
+
+- [ ] Verify `firmware_download.py` SHA-256 verification code path (lines 268-282) is working
+- [ ] Confirm test suite runs cleanly: `python3 tests.py`
+- [ ] Review current manifest state: `bf-f8hp-pro` and `bf-f8hp-pro-nrfb` are pinned; `uv-25-pro`, `rt-470`, `rt-490` are null
+
+## For Each Unpinned Entry
+
+### uv-25-pro (UV-25 Plus)
+
+1. [ ] Download the bundle from `https://baofeng.s3.amazonaws.com/Baofeng_UV-25_Plus_Firware_Update_Guide_20250526.zip`
+2. [ ] Extract and verify bundle contains expected firmware file (pattern: `*.kdhx`)
+3. [ ] Inspect extracted firmware to confirm it matches UV-25 Plus (check header, validate against radios.json `firmware_filename_pattern`)
+4. [ ] Calculate SHA-256 hash of the bundle file (use `sha256sum` or Python `hashlib`)
+5. [ ] Record the hash and update `firmware_manifest.json` entry
+6. [ ] Document the firmware version confirmed in `release_notes` (currently "V0.20")
+
+### rt-470 (Radtel RT-470 series)
+
+1. [ ] Download the bundle from `https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_RT470X_RT470L_NEW_PCB_8.33KHZ_V2.13C_20240425.rar`
+2. [ ] Extract and verify bundle contains expected firmware file (pattern: `*.kdhx`)
+3. [ ] Inspect extracted firmware to confirm it matches RT-470 new PCB (radios.json specifies this variant)
+4. [ ] Calculate SHA-256 hash of the bundle file
+5. [ ] Record the hash and update `firmware_manifest.json` entry
+6. [ ] Document the firmware version confirmed in `release_notes` (currently "V2.13C")
+
+### rt-490 (Radtel RT-490 old PCB)
+
+1. [ ] Download the bundle from `https://cdn.shopify.com/s/files/1/0564/8855/8800/files/Firmware_Version_1.03.zip`
+2. [ ] Extract and verify bundle contains expected firmware file (pattern: `*.kdhx`)
+3. [ ] Inspect extracted firmware to confirm it matches RT-490 old PCB variant
+4. [ ] Calculate SHA-256 hash of the bundle file
+5. [ ] Record the hash and update `firmware_manifest.json` entry
+6. [ ] Document the firmware version confirmed in `release_notes` (currently "V1.03")
+
+## Manifest Update
+
+- [ ] Update `firmware_manifest.json` with the three new hashes
+- [ ] Verify all non-null `firmware_url` entries now have non-null `firmware_sha256`
+- [ ] Update `_updated` timestamp to reflect change date
+- [ ] Verify `manifest_version` is consistent (currently 1)
+
+## Test Coverage
+
+- [ ] Add test `TestManifestSchema.test_all_entries_with_url_must_have_hash()`:
+  - Assert: for every entry in manifest with non-null `firmware_url`, `firmware_sha256` is non-null
+  - This gate prevents future unpinned entries from being merged
+- [ ] Run test suite to confirm new test passes: `python3 tests.py TestManifestSchema`
+
+## Documentation & Changelog
+
+- [ ] Update `CHANGELOG.md` with entry in the target release section:
+  ```
+  - Pin SHA-256 hashes for all firmware downloads (uv-25-pro, rt-470, rt-490); 
+    future unpinned entries blocked by test gate
+  ```
+- [ ] Verify no other documentation files reference the manifest schema
+- [ ] (Optional) Update project context in `openspec/project.md` if domain notes need clarification on firmware safety
+
+## Verification
+
+- [ ] `python3 tests.py` passes all tests including new hash-pinning gate
+- [ ] Manual spot-check: simulate a download with a pinned hash; verify correct hash is passed to `firmware_download.py`
+- [ ] Manual spot-check: simulate hash mismatch; verify error message is actionable (current message: "The downloaded file may be corrupted or tampered with")
+- [ ] No regressions in existing pinned entries (bf-f8hp-pro, bf-f8hp-pro-nrfb)
+
+## Final Checklist
+
+- [ ] All three bundles downloaded, inspected, and hashes recorded
+- [ ] `firmware_manifest.json` updated with hashes
+- [ ] Test added and passing
+- [ ] `CHANGELOG.md` updated
+- [ ] PR created with summary and test results

--- a/openspec/changes/translation-review-process/proposal.md
+++ b/openspec/changes/translation-review-process/proposal.md
@@ -1,0 +1,37 @@
+# Translation Review Process — Proposal
+
+## Why
+
+All 7 non-English catalogs (translations/zh-CN.json, fr.json, de.json, it.json, es.json, ar.json, ru.json) are machine-translated stubs marked `_meta.reviewed: false`. Many translation keys are innocuous (button labels, hints), but safety-critical strings demand native-speaker review:
+
+- **radio.*.bootloader_keys**: Step-by-step instructions to enter bootloader mode. Errors here cause users to fail to flash, or worse, enter a wrong mode on their radio.
+- **radio.*.notes**: Hardware-variant warnings (BF-F8HP Pro NRF vs NRFB; RT-490 old vs new PCB) that prevent bricking. Wrong interpretation of these notes can brick a radio permanently.
+- **dialog.confirm_***: Confirmation dialogs that repeat bootloader instructions and warn about safety (power off, hold keys, screen blank, green LED). Poor translation here undermines the warning's urgency.
+- **dialog.untested_***: Warnings about untested radios. Translation must convey risk.
+
+The app has 162 non-radio translation strings organized in logical groups (button, tooltip, dialog, log, hint, etc.). The 7 required languages add ~40 dynamic radio-specific strings per radio definition. Tests already enforce completeness (`TestRadioStringTranslations`) and reject English-echo translations, but there is no process to surface review work to the community or track review progress.
+
+## What Changes
+
+1. **Community review tracking**: Create per-language GitHub issues (7 total) with a prioritized checklist of key groups. Each language issue tracks which key groups have been reviewed and fixed by native speakers.
+
+2. **CONTRIBUTING.md**: Add a new "Translations" section documenting:
+   - The review process: how to identify untranslated or echo strings, fix them, and test locally
+   - Safety-critical priorities (radio.* fields, dialog strings)
+   - Test expectations: the no-echo rule (translated strings must differ from English), completeness rule (all keys present), and how tests gate PRs
+   - Where to find review tracking (language-specific issues)
+
+3. **_meta.reviewed convention**: Mark each catalog `_meta.reviewed: true` only after a native speaker has reviewed and fixed all safety-critical strings. Whole-file bool chosen for simplicity: if a catalog is marked reviewed, all its strings (especially bootloader keys and hardware warnings) have been vetted by someone who speaks the language fluently. The test suite ensures no partial states slip through (completeness and no-echo tests catch drift).
+
+4. **Optional in-app hint**: Annotate the language picker with "Machine translated — help review" for any language where `_meta.reviewed: false`. Helps users select a language knowing it may need improvement, and encourages contribution.
+
+## Impact
+
+- **For contributors**: Clear, trackable process to review translations. Tests give immediate feedback on quality. No new tools or infrastructure needed.
+- **For users**: Unreviewed languages remain usable (fallback to English for missing keys), but they know which languages are native-reviewed. Reviewed languages have reliable safety-critical strings.
+- **For safety**: Bootloader instructions and hardware warnings in 7 languages can now be reviewed by people who actually speak them. Issues are public, inviting community participation.
+- **For maintenance**: Low overhead — just issues and a CONTRIBUTING section. The existing test suite already enforces the quality gates.
+
+---
+
+**Related context**: Current README mentions "community review PRs welcome" but provides no process. Safety-critical strings (bootloader sequences, hardware-variant notes) carry risk if mistranslated.

--- a/openspec/changes/translation-review-process/specs/i18n-review/spec.md
+++ b/openspec/changes/translation-review-process/specs/i18n-review/spec.md
@@ -1,0 +1,353 @@
+# Translation Review Process — Specification
+
+## Overview
+
+This specification defines the process and system requirements for tracking and managing community review of non-English translations in FlintWave Flash. The goal is to ensure that safety-critical strings (bootloader instructions, hardware warnings, confirmation dialogs) are validated by native speakers before a language is marked as reviewed.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Safety-Critical String Identification
+
+**Requirement**: The system SHALL identify and prioritize safety-critical translation keys that demand native-speaker review.
+
+#### Scenario: Bootloader Instruction Keys
+- **Given**: A radio entry in `radios.json` with a `bootloader_keys` field
+- **When**: That field is translated into a non-English language and stored in `translations/<code>.json` under key `radio.<id>.bootloader_keys`
+- **Then**: The translation SHALL be reviewed by a native speaker to ensure the step-by-step instructions are clear and match the English intent (e.g., button labels, key sequences, timing)
+- **Rationale**: Mistakes in bootloader instructions cause flashing failures; users may inadvertently put the radio in the wrong mode
+
+#### Scenario: Hardware Variant Warnings
+- **Given**: A radio entry in `radios.json` with a `notes` field containing variant warnings (e.g., "NRF and NRFB firmware are NOT interchangeable")
+- **When**: That field is translated into a non-English language and stored as `radio.<id>.notes`
+- **Then**: The translation SHALL be reviewed by a native speaker to ensure the warning is unambiguous and conveys the risk (bricking if wrong variant is selected)
+- **Rationale**: Mistranslation of variant warnings can lead to permanent hardware damage
+
+#### Scenario: Confirmation Dialog Keys
+- **Given**: Confirmation dialogs (`dialog.confirm_single`, `dialog.confirm_batch_*`) that show before flashing begins
+- **When**: These dialogs are translated and stored in `translations/<code>.json`
+- **Then**: The translation SHALL preserve the urgency of safety warnings ("Do not disconnect," "green Rx LED," bootloader key sequence legibility)
+- **Rationale**: These dialogs are the last chance to warn users before an irreversible operation
+
+#### Scenario: Untested Radio Warnings
+- **Given**: Dialogs that warn users about untested radios (`dialog.untested_*`)
+- **When**: Translated into a non-English language
+- **Then**: The translation SHALL convey the risk of flashing firmware on untested hardware
+- **Rationale**: Untested radios may not follow the KDH protocol exactly; mistranslation of this risk could encourage users to ignore warnings
+
+---
+
+### Requirement: Reviewed State Tracking
+
+**Requirement**: The system SHALL track the review status of each language catalog via the `_meta.reviewed` field.
+
+#### Scenario: Whole-Catalog Reviewed State
+- **Given**: A language catalog `translations/<code>.json`
+- **When**: A native speaker has reviewed and fixed all safety-critical strings (radio.*, dialog.confirm_*, dialog.untested_*), plus any obvious echo or completeness issues
+- **Then**: The catalog's `_meta.reviewed` field SHALL be set to `true`
+- **Rationale**: A boolean is simple to check in code (i18n.py), simple to update (one edit, no partial states), and sufficient for safety: if reviewed=true, all safety-critical keys have been validated
+
+#### Scenario: Unreviewed Catalogs
+- **Given**: Any non-English language at initial import or after a new radio is added
+- **When**: The catalog has not been reviewed by a native speaker
+- **Then**: `_meta.reviewed` SHALL be `false`
+- **Consequence**: The language is marked as "Machine translated — help review" in the UI (optional but recommended)
+- **Rationale**: Users can choose to use the language knowing it may need improvement; contributors see a call to action
+
+#### Scenario: Fallback Behavior
+- **Given**: A language with `_meta.reviewed: false`
+- **When**: A string is missing or not yet translated
+- **Then**: The app SHALL fall back to English for that key (existing i18n.py behavior)
+- **Consequence**: The app remains usable in unreviewed languages; only reviewed languages guarantee complete, safe translations
+- **Rationale**: Graceful degradation; no lockout for incomplete translations
+
+---
+
+### Requirement: Contribution Documentation
+
+**Requirement**: The system SHALL document the translation review process for community contributors.
+
+#### Scenario: Translator Onboarding
+- **Given**: A contributor who speaks ‹Language› fluently and wants to review that language's translation
+- **When**: They consult `CONTRIBUTING.md`
+- **Then**: The Translations section SHALL provide:
+  1. A clear definition of "safety-critical strings" (radio.*, dialog.confirm_*, dialog.untested_*)
+  2. Step-by-step instructions: find the tracking issue, fix strings locally, run tests, submit a PR
+  3. Examples of how to avoid the "English echo" trap (translations must differ from English)
+  4. Explanation of test expectations: completeness and no-echo checks
+- **Rationale**: Lower barrier to entry; clear expectations; actionable guidance
+
+#### Scenario: Test Expectations Documented
+- **Given**: A translator reading `CONTRIBUTING.md`
+- **When**: They review the "Test Expectations" section
+- **Then**: They SHALL understand:
+  1. The `test_every_radio_field_translated_in_every_lang` test requires all `radio.<id>.<field>` keys present in every language
+  2. The `test_translations_are_actually_translated` test rejects any `radio.<id>.<field>` value identical to English (catches model echo and copy-paste)
+  3. Both tests must pass for a PR to merge
+- **Consequence**: Translators can run tests locally before submitting a PR and fix issues immediately
+- **Rationale**: Tests provide fast feedback; translators unblock themselves without waiting for maintainer review
+
+#### Scenario: Safety-Critical Prioritization
+- **Given**: A translator with limited time
+- **When**: They review `CONTRIBUTING.md`
+- **Then**: The Translations section SHALL prioritize key groups:
+  1. 🔴 CRITICAL: radio.*, dialog.confirm_*, dialog.untested_*
+  2. 🟡 IMPORTANT: dialog.* (other), hint.*, log.*
+  3. 🟢 NICE-TO-HAVE: button.*, tooltip.*, status.*, etc.
+- **Consequence**: A partial review (e.g., CRITICAL + IMPORTANT) is clearly valuable; nice-to-have groups are deprioritized but available for thoroughness
+- **Rationale**: Incremental contribution model; encourages participation even if not comprehensive
+
+---
+
+### Requirement: Per-Language Review Tracking
+
+**Requirement**: The system SHALL provide per-language GitHub issues to track review progress and invite community participation.
+
+#### Scenario: Issue Creation
+- **Given**: Each of the 7 non-English languages (zh-CN, fr, de, it, es, ar, ru)
+- **When**: The translation review process is initiated
+- **Then**: A GitHub issue SHALL be created for each language with:
+  1. Title: ‹Language› (‹code›) Translation Review
+  2. A prioritized checklist (CRITICAL, IMPORTANT, NICE-TO-HAVE groups)
+  3. Instructions for contributors (link to CONTRIBUTING.md)
+  4. A space to track merged PRs per group
+- **Consequence**: Contributors see at a glance which groups need review; maintainers can track progress
+- **Rationale**: Public, trackable way to invite and coordinate community contributions
+
+#### Scenario: Progress Tracking
+- **Given**: A PR that reviews and fixes some key groups in ‹Language›
+- **When**: The PR is merged
+- **Then**: The maintainer updates the tracking issue to mark those groups as reviewed and link the PR
+- **Consequence**: Issue checklist reflects merged work; contributors see progress; the next reviewer knows what's left
+- **Rationale**: Transparency and coordination; prevents duplicate work
+
+#### Scenario: Issue Closure
+- **Given**: All CRITICAL and IMPORTANT groups for a language have been reviewed and merged
+- **When**: `_meta.reviewed` is set to `true` in the language's JSON
+- **Then**: The tracking issue SHALL be closed
+- **Consequence**: The language is marked as reviewed; the language picker no longer shows "Machine translated" hint
+- **Rationale**: Clear end state; signals to users that the language is native-reviewed
+
+---
+
+### Requirement: In-App Language Picker Hint (Optional)
+
+**Requirement**: The language picker MAY display a hint for unreviewed languages to encourage contribution.
+
+#### Scenario: Language Label for Unreviewed Languages
+- **Given**: A language where `_meta.reviewed: false` (e.g., French)
+- **When**: The user opens the language picker dialog or dropdown
+- **Then**: The language label MAY be annotated with " — Machine translated, help review"
+  - Example: "Français — Machine translated, help review"
+- **Consequence**: Users are aware the language may need improvement; they see an implicit call to review
+- **Rationale**: Low-friction way to invite contributions; contextual and non-intrusive
+
+#### Scenario: No Hint for Reviewed Languages
+- **Given**: A language where `_meta.reviewed: true` (or English, which is always reviewed)
+- **When**: The user opens the language picker
+- **Then**: The label shows normally without a hint
+- **Consequence**: Reviewed languages stand out implicitly (no suffix)
+- **Rationale**: Simplicity; no clutter for reviewed languages
+
+---
+
+### Requirement: Test Suite Quality Gates (Existing)
+
+**Requirement**: The system SHALL enforce translation quality via the existing test suite.
+
+#### Scenario: Completeness Check
+- **Given**: A PR that modifies a non-English translation file
+- **When**: Tests run (`python3 tests.py TestRadioStringTranslations`)
+- **Then**: The `test_every_radio_field_translated_in_every_lang` test SHALL verify:
+  - For every radio in `radios.json` with a `bootloader_keys`, `connector`, or `notes` field
+  - And for every required language (zh-CN, fr, de, it, es, ar, ru)
+  - The key `radio.<id>.<field>` exists in `translations/<code>.json`
+- **Consequence**: Missing radio.* translations block the PR
+- **Rationale**: Guarantees no language has incomplete radio metadata
+
+#### Scenario: English Echo Prevention
+- **Given**: A PR that modifies a non-English translation file
+- **When**: Tests run
+- **Then**: The `test_translations_are_actually_translated` test SHALL verify:
+  - For every `radio.<id>.<field>` key
+  - In every required language
+  - The translated value is NOT identical to the English source (modulo whitespace)
+- **Consequence**: Exact copies of English strings block the PR
+- **Rationale**: Catches machine-translation failures and copy-paste errors; ensures effort has been made to translate
+
+---
+
+## Non-Requirements
+
+- **Automated machine translation**: This spec does not mandate automated translation tooling. Translations are assumed to be reviewed and fixed manually by native speakers.
+- **Translation memory or TMS**: No external translation management system is required. GitHub issues and the existing file structure are sufficient.
+- **Translation of in-app changelogs or release notes**: Only the UI strings (`translations/*.json`) are in scope. Release notes stay in English.
+- **Versioning of _meta**: No version field is added to `_meta`; `_meta.reviewed` is a boolean, not versioned. Breaking changes (e.g., restructuring keys) are out of scope.
+
+---
+
+## Design Rationale
+
+### Why `_meta.reviewed` as a Whole-Catalog Boolean?
+
+**Alternative considered**: Per-section granularity (e.g., `_meta.sections.radio_reviewed: true`, `_meta.sections.dialog_reviewed: true`).
+
+**Decision**: Whole-catalog boolean.
+
+**Rationale**:
+1. **Simplicity**: A single bool is trivial to check in code (`if i18n.is_reviewed(code)`), simple for maintainers to update, and clear to users
+2. **Sufficient safety**: Tests enforce completeness and no-echo for all strings, so any drift is caught quickly
+3. **Signal clarity**: Reviewed=true means all strings (especially safety-critical ones) have been validated by a native speaker; no partial states
+4. **Low maintenance**: No need to track or reconcile multiple sub-sections; avoids state inconsistency (e.g., radio reviewed but dialogs not)
+
+If granular tracking becomes necessary in the future, per-section fields can be added to `_meta` without breaking this spec; the simple boolean remains the primary gate.
+
+### Why GitHub Issues for Tracking?
+
+**Alternative considered**: Wiki page, spreadsheet, dedicated tool.
+
+**Decision**: GitHub issues (one per language).
+
+**Rationale**:
+1. **Decentralized coordination**: Issues show work in progress; contributors claim groups to avoid duplication
+2. **Audit trail**: Issue history and linked PRs provide a clear record of who reviewed what and when
+3. **Integration with CI/CD**: PR links in issue updates create natural traceability
+4. **Low barrier**: No new tools or logins required; everyone uses GitHub anyway
+5. **Community invitation**: Public issues invite participation; easier to find than a hidden wiki
+
+### Why CONTRIBUTING.md?
+
+**Alternative considered**: Separate translation guide, in-app help, video tutorials.
+
+**Decision**: CONTRIBUTING.md.
+
+**Rationale**:
+1. **Standard location**: Developers and contributors expect contribution guidelines in CONTRIBUTING.md
+2. **Accessible offline**: Works without network; can be read before cloning
+3. **Version control**: Changes to the process are tracked in git and easy to reference
+4. **Searchable**: Easy to link from README and issues
+
+Additional materials (wiki, videos) can complement CONTRIBUTING.md but are not primary.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Process & Documentation (Minimal)
+1. Create CONTRIBUTING.md with Translations section
+2. Create 7 per-language GitHub issues with checklists
+3. Update README.md to mention the review process
+4. Document `_meta.reviewed` convention in code comments
+
+**Impact**: Low effort, immediate invitation for contributions. Existing tests already enforce quality.
+
+### Phase 2: In-App Hint (Optional, Nice-to-Have)
+1. Add `is_reviewed(code)` helper to i18n.py
+2. Annotate language labels in picker with "Machine translated" hint for unreviewed languages
+3. Test that labels display and language switching still works
+
+**Impact**: Minimal code (10-20 lines), visual signal to users about review status.
+
+### Phase 3: Maintenance (Ongoing)
+1. When a PR reviews a language's key groups, maintainer marks issue checklist items as done
+2. When all CRITICAL and IMPORTANT groups are reviewed, maintainer sets `_meta.reviewed: true` and closes the issue
+3. If a new radio is added to radios.json, maintainers add the corresponding radio.* keys to all translation files and mark existing languages as needing review again
+
+---
+
+## Testing & Validation
+
+### Manual Testing Checklist
+- [ ] Verify CONTRIBUTING.md is clear and correct (have someone non-native read it)
+- [ ] Verify GitHub issues have correct links and formatting
+- [ ] Verify existing test suite still passes: `python3 tests.py`
+- [ ] (If in-app hint implemented) Verify language picker displays correctly with new labels
+- [ ] (If in-app hint implemented) Verify Arabic RTL layout works with longer labels
+- [ ] (If in-app hint implemented) Verify language switching still works
+
+### Automated Testing
+- Existing tests (`TestRadioStringTranslations`) automatically enforce completeness and no-echo
+- No new automated tests required for the tracking process itself (GitHub issues are not part of the codebase)
+
+---
+
+## Success Criteria
+
+1. **Adoption**: At least one native speaker per language submits a PR reviewing and fixing CRITICAL + IMPORTANT groups within 60 days
+2. **Coverage**: At least 5 of 7 languages reach `_meta.reviewed: true` (at least CRITICAL + IMPORTANT groups reviewed)
+3. **Quality**: All merged PRs pass existing test suite; zero echo failures; zero completeness failures
+4. **Process clarity**: Contributors report that CONTRIBUTING.md is clear and they can run tests and submit PRs without friction
+5. **Sustainability**: Maintainers can update tracking issues efficiently; adding a new radio doesn't derail the process
+
+---
+
+## Appendix A: Example Translation Checklist (per-language issue)
+
+```markdown
+## Chinese (zh-CN) Translation Review
+
+[ ] CRITICAL — Safety-Critical Strings
+  [ ] radio.*.bootloader_keys (7 keys) — [PR #NNN]
+  [ ] radio.*.notes (7 keys) — [PR #NNN]
+  [ ] dialog.confirm_* (3 keys) — [PR #NNN]
+  [ ] dialog.untested_* (3 keys) — [PR #NNN]
+
+[ ] IMPORTANT — UI Workflow Strings
+  [ ] dialog.* other (37 keys) — [PR #OOO]
+  [ ] hint.* (26 keys) — [PR #OOO]
+  [ ] log.* (59 keys) — [PR #PPP]
+
+[ ] NICE-TO-HAVE — UI Chrome
+  [ ] button.* (13 keys) — [PR #QQQ]
+  [ ] tooltip, statusbar, titlebar, status, column, app, info, etc. (20 keys) — [PR #QQQ]
+
+**When CRITICAL + IMPORTANT are done**: A maintainer will set `_meta.reviewed: true` and close this issue.
+```
+
+---
+
+## Appendix B: i18n.py Integration
+
+Helper function to add to `i18n.py`:
+
+```python
+def is_reviewed(code: str) -> bool:
+    """Check if a language catalog has been reviewed by a native speaker.
+    
+    Returns True if _meta.reviewed is true in the language's bundled or cached catalog.
+    English is always considered reviewed.
+    """
+    if code == "en":
+        return True
+    
+    # Check bundled catalog first (for testing)
+    bundled_path = os.path.join(_bundled_translations_dir(), f"{code}.json")
+    data = _read_json_file(bundled_path)
+    if data and data.get("_meta", {}).get("reviewed") is True:
+        return True
+    
+    # Check cached catalog
+    cached = _load_cached(code)
+    if cached:
+        # Note: _load_cached strips _meta, so we need to re-read with _meta
+        cache_path = os.path.join(_cache_translations_dir(), f"{code}.json")
+        data = _read_json_file(cache_path)
+        if data and data.get("_meta", {}).get("reviewed") is True:
+            return True
+    
+    return False
+```
+
+Usage in language picker:
+
+```python
+# In the language picker UI code:
+for code, label in i18n.LANGUAGES:
+    if code == "en":
+        display_label = label
+    else:
+        suffix = "" if i18n.is_reviewed(code) else " — Machine translated, help review"
+        display_label = f"{label}{suffix}"
+    # Render display_label in the dropdown
+```

--- a/openspec/changes/translation-review-process/tasks.md
+++ b/openspec/changes/translation-review-process/tasks.md
@@ -1,0 +1,363 @@
+# Translation Review Process — Implementation Tasks
+
+## 1. CONTRIBUTING.md: Add Translations Section
+
+- [ ] Create `CONTRIBUTING.md` at the repo root with:
+  
+  ```markdown
+  ## Translations
+  
+  ### How Translation Works
+  
+  FlintWave Flash ships with English (bundled) and 7 optional languages:
+  - Chinese (Simplified): zh-CN
+  - French: fr
+  - German: de
+  - Italian: it
+  - Spanish: es
+  - Arabic: ar (RTL layout)
+  - Russian: ru
+  
+  English lives in `translations/en.json` and is the source of truth. 
+  Non-English translations are in `translations/<code>.json` and are initially machine-translated.
+  When you pick a non-English language in the app for the first time, it downloads from GitHub and caches locally.
+  
+  ### Safety-Critical Strings
+  
+  Some strings carry user-safety implications:
+  
+  1. **Radio bootloader instructions** (`radio.<id>.bootloader_keys`):
+     - English source in `radios.json` defines the key-press sequence to enter bootloader mode
+     - Translated versions must match *the intent* even if exact button names differ by region
+     - Example: if English says "SK1 + SK2", the translation should match those button labels in that language/market
+     - Errors here can cause users to fail flashing or inadvertently put the radio in wrong mode
+  
+  2. **Hardware variant warnings** (`radio.<id>.notes`):
+     - Many radios have variants with incompatible firmware (BF-F8HP Pro NRF/NRFB, RT-490 old/new PCB)
+     - The notes section explicitly warns against flashing the wrong variant
+     - **Critical**: mistranslation here can lead to permanent bricking
+     - Read the English notes carefully and ensure the warning is clear in the target language
+  
+  3. **Confirmation dialogs** (`dialog.confirm_single`, `dialog.confirm_batch_*`):
+     - These are the final safety-check dialogs shown before flashing
+     - They repeat the bootloader key sequence and emphasize "do not disconnect during flash"
+     - Translation must preserve urgency and clarity
+  
+  4. **Untested radio warnings** (`dialog.untested_*`):
+     - Warn users when flashing firmware to radios that haven't been validated with this tool
+     - Translation must convey the risk appropriately
+  
+  ### Reviewing Translations
+  
+  #### Step 1: Find your language's tracking issue
+  
+  Each language has a GitHub issue tracking review progress:
+  - [#N0] Chinese (zh-CN) Translation Review
+  - [#N1] French (fr) Translation Review
+  - [#N2] German (de) Translation Review
+  - [#N3] Italian (it) Translation Review
+  - [#N4] Spanish (es) Translation Review
+  - [#N5] Arabic (ar) Translation Review
+  - [#N6] Russian (ru) Translation Review
+  
+  Check the issue's checklist to see which key groups still need review.
+  
+  #### Step 2: Fix strings locally
+  
+  1. Clone the repo:
+     ```bash
+     git clone https://github.com/FlintWave/flintwave-kdh-flasher.git
+     cd flintwave-kdh-flasher
+     ```
+  
+  2. Edit `translations/<code>.json` with a text editor (not Google Translate).
+     - Keep the JSON structure intact (keys, spacing, quotes)
+     - Edit only the string values, not the keys
+     - For radio.* fields, check `radios.json` for the English source
+  
+  3. Prioritize safety-critical strings first (radio.* fields, then dialog.confirm_*, dialog.untested_*).
+  
+  4. Tips for avoiding the "English echo" trap:
+     - Tests reject translations identical to English
+     - Don't just copy-paste the English value
+     - If you can't translate a term (e.g., "SK1" in bootloader_keys), keep it as-is but translate the surrounding text
+     - Some technical terms may not have standard translations; research your language's radio community first
+  
+  #### Step 3: Test locally (optional but recommended)
+  
+  ```bash
+  # Run the test suite to catch completeness and echo errors:
+  python3 tests.py TestRadioStringTranslations
+  
+  # Or run the full test suite:
+  python3 tests.py
+  ```
+  
+  This verifies:
+  - All radio.* keys are present in your language
+  - None of your translations are identical to the English source (the "echo" check)
+  
+  #### Step 4: Submit a PR
+  
+  1. Create a branch: `git checkout -b translate/<code>`
+  2. Commit your changes:
+     ```bash
+     git add translations/<code>.json
+     git commit -m "Review and fix <language> translation: <key groups reviewed>"
+     ```
+  3. Push and create a PR, linking to the tracking issue (e.g., "Addresses #N0").
+  4. In the PR description, list which key groups you've reviewed:
+     ```
+     ## Translation Review: <language>
+     
+     Reviewed and fixed:
+     - [x] radio.* (bootloader_keys, connector, notes)
+     - [x] dialog.confirm_*, dialog.untested_*
+     - [x] button, tooltip, hints
+     ```
+  
+  #### Step 5: Maintainer merges and marks reviewed
+  
+  Once a language's safety-critical strings (radio.*, dialog.confirm_*, dialog.untested_*) have been reviewed by a native speaker:
+  
+  1. Maintainer sets `_meta.reviewed: true` in the catalog
+  2. Maintainer closes the tracking issue
+  3. The language picker in the app no longer shows "Machine translated — help review"
+  
+  ### Test Expectations
+  
+  Two tests gate translation PRs:
+  
+  1. **Completeness** (`test_every_radio_field_translated_in_every_lang`):
+     - Every `radio.<id>.<field>` key in English must exist in every non-English catalog
+     - Ensures no language is missing critical hardware or bootloader info
+  
+  2. **No Echo** (`test_translations_are_actually_translated`):
+     - No `radio.<id>.<field>` value can be identical to the English source
+     - Catches copy-paste errors and machine-translation failures
+     - If a term (e.g., "K1 Kenwood 2-pin") has no translation, leave it as-is in quotes (to differ from the raw string)
+  
+  Both tests run on every PR. If they fail, the PR cannot merge.
+  
+  ### File Format
+  
+  Translation files are JSON:
+  ```json
+  {
+    "_meta": {
+      "language": "de",
+      "language_label": "Deutsch",
+      "reviewed": false,
+      "source": "machine"
+    },
+    "app.title": "FlintWave Flash",
+    "button.flash_firmware": "Firmware flashen",
+    "radio.bf-f8hp-pro.bootloader_keys": "SK1 + SK2 ...",
+    ...
+  }
+  ```
+  
+  The `_meta` section is metadata; the tests strip it before loading. When `_meta.reviewed` is set to `true`, it signals that a native speaker has checked all strings (especially safety-critical ones).
+  ```
+
+- [ ] Verify the file is readable and correctly formatted
+
+## 2. Create Per-Language Tracking Issues
+
+Create 7 GitHub issues (one per non-English language) with the following template:
+
+### Issue Template
+
+**Title**: `<Language> (‹code›) Translation Review`
+
+**Body**:
+```markdown
+## Overview
+
+The ‹Language› translation (`translations/‹code›.json`) is currently machine-translated and marked `_meta.reviewed: false`.
+
+This issue tracks community review of the ‹Language› strings, prioritizing safety-critical ones:
+
+## Key Groups (Priority Order)
+
+### 🔴 CRITICAL — Safety-Critical Strings (Must be reviewed by a native speaker)
+
+These strings affect user safety. Mistranslation can cause flashing failures or hardware damage.
+
+- **radio.*.bootloader_keys** — ~7 keys, step-by-step bootloader mode instructions
+  - [ ] Reviewed: all bootloader key sequences match English intent, clear for native speaker
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **radio.*.notes** — ~7 keys, hardware-variant warnings (e.g., "NRF vs NRFB not interchangeable")
+  - [ ] Reviewed: all variant warnings are clear and warn against wrong firmware
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **dialog.confirm_single, dialog.confirm_batch_title, dialog.confirm_batch_body** — 3 keys
+  - [ ] Reviewed: confirmation dialogs are clear, bootloader key sequence is legible, warnings preserve urgency
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **dialog.untested_title, dialog.untested_body, dialog.untested_warning** — 3 keys
+  - [ ] Reviewed: untested radio warnings are clear and convey risk
+  - Tracking: Opened [PR linking], merged [date]
+
+### 🟡 IMPORTANT — UI Workflow Strings
+
+Dialog text, error messages, and workflow hints. Affect user experience but not safety.
+
+- **dialog.* (error dialogs, report submission)** — ~37 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **hint.* (workflow instructions)** — ~26 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **log.* (progress and diagnostic messages)** — ~59 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+
+### 🟢 NICE-TO-HAVE — UI Chrome
+
+Button labels, tooltips, status messages. Low-impact but nice to have correct.
+
+- **button.* (button labels)** — 13 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **tooltip.*,statusbar.*,titlebar.* (UI labels)** — ~15 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+  
+- **status.*, column.*, app.*, info.*, etc.** — ~20 keys
+  - [ ] Reviewed
+  - Tracking: Opened [PR linking], merged [date]
+
+## When All Critical + Important Groups Are Reviewed
+
+Once all 🔴 CRITICAL and 🟡 IMPORTANT groups are reviewed and merged:
+
+1. A maintainer will set `_meta.reviewed: true` in `translations/‹code›.json`
+2. The language picker in the app will no longer show "Machine translated — help review"
+3. This issue will be closed
+
+## How to Help
+
+See [CONTRIBUTING.md → Translations](#translations) for the step-by-step review and PR process.
+
+**We're looking for native speakers** who can:
+- Spot awkward phrasing or mistranslations
+- Ensure safety-critical warnings are clear in ‹Language›
+- Review at least the 🔴 CRITICAL and 🟡 IMPORTANT groups
+
+Even partial reviews welcome! Comment on the issue to claim a group so others know someone is working on it.
+```
+
+Create these 7 issues with language-specific titles:
+- [ ] GitHub Issue #N0: Chinese (zh-CN) Translation Review
+- [ ] GitHub Issue #N1: French (fr) Translation Review
+- [ ] GitHub Issue #N2: German (de) Translation Review
+- [ ] GitHub Issue #N3: Italian (it) Translation Review
+- [ ] GitHub Issue #N4: Spanish (es) Translation Review
+- [ ] GitHub Issue #N5: Arabic (ar) Translation Review
+- [ ] GitHub Issue #N6: Russian (ru) Translation Review
+
+## 3. Update _meta Convention in Existing Translations
+
+All non-English translation files currently have `_meta.reviewed: false`. Document the convention:
+
+- [ ] Update i18n.py docstring or inline comment explaining `_meta.reviewed`:
+  - `true` = all strings (especially safety-critical: radio.*, dialog.confirm_*, dialog.untested_*) reviewed by native speaker
+  - `false` = machine-translated, awaiting community review (see GitHub issues for tracking)
+  - [ ] Add comment in en.json's _meta block:
+    ```json
+    "_meta": {
+      "language": "en",
+      "language_label": "English",
+      "reviewed": true,
+      "source": "canonical",
+      "_comment": "Reviewed=true means all strings, especially safety-critical ones (radio.*, dialog.confirm_*, dialog.untested_*), have been checked by a native speaker"
+    }
+    ```
+
+## 4. Optional: In-App Hint for Unreviewed Languages
+
+Annotate the language picker dropdown to signal review status. This is optional but encourages contribution.
+
+- [ ] In `gui_main.py` (or the language-picker component), locate the language selection dropdown or dialog
+- [ ] When rendering a language option, append " — Machine translated, help review" if `_meta.reviewed: false`
+  - Example: "Français — Machine translated, help review"
+  - English always shows as "English" (no suffix)
+  
+  To implement:
+  ```python
+  # Pseudo-code in the language dialog:
+  for code, label in i18n.LANGUAGES:
+      if code == "en":
+          display_label = label
+      else:
+          is_reviewed = load_reviewed_status(code)  # Read _meta.reviewed from cached/bundled file
+          suffix = "" if is_reviewed else " — Machine translated, help review"
+          display_label = f"{label}{suffix}"
+  ```
+  
+  Helper function to check review status:
+  - [ ] Add function in `i18n.py`: `is_reviewed(code: str) -> bool`
+    - Check `_meta.reviewed` in the bundled or cached catalog for that language
+    - Return `True` for en (always reviewed), `False` for any language marked `reviewed: false`
+  
+- [ ] Test that the label appears correctly in the language picker dropdown (manual verification)
+- [ ] Verify that switching languages still works (no regression)
+- [ ] Verify Arabic RTL layout still works with the additional text
+
+## 5. Tests (if any)
+
+The existing test suite (`tests.py`) already enforces:
+- Completeness: all radio.* keys present in every language
+- No echo: no radio.* value identical to English
+
+No new tests are required for this proposal. However, maintainers may wish to add:
+
+- [ ] (Optional) Test that `_meta.reviewed` is a bool (not null or string)
+  - This prevents misconfigurations when a maintainer updates _meta
+
+## 6. Documentation & Changelog
+
+- [ ] Update `README.md` Languages section to mention the review process:
+  ```markdown
+  ### Languages
+  
+  … existing language list …
+  
+  The non-English catalogs are initially machine-translated. 
+  Community native-speaker review is ongoing — see the [Translations](#translations) section of [CONTRIBUTING.md](CONTRIBUTING.md) for how to help.
+  Unreviewed languages are marked in the language picker; reviewed languages have been checked by a native speaker.
+  ```
+
+- [ ] Update `CHANGELOG.md` in the target release section:
+  ```
+  - Add community translation review process with per-language tracking issues
+  - Add Translations section to CONTRIBUTING.md with review workflow and test expectations
+  - Update _meta convention: _meta.reviewed tracks native-speaker review status (safety-critical strings)
+  - (Optional) Add in-app hint in language picker for unreviewed languages
+  ```
+
+- [ ] Update `openspec/project.md` if clarification is needed on translation safety:
+  ```markdown
+  ### Internationalization & Review
+  
+  English is bundled; 7 other languages download on demand and cache locally.
+  Translations are organized by key prefix (radio.*, dialog.*, log.*, etc.).
+  Safety-critical strings (bootloader_keys, hardware warnings, confirmation dialogs) are tracked in per-language GitHub issues
+  and marked _meta.reviewed: true only after native-speaker review.
+  See CONTRIBUTING.md → Translations for the review process.
+  ```
+
+## 7. Final Verification
+
+- [ ] `python3 tests.py` passes (no new tests break existing ones)
+- [ ] CONTRIBUTING.md is readable and clear (ask a non-native speaker to review the translation section)
+- [ ] GitHub issues are created and properly formatted
+- [ ] README.md and CHANGELOG.md updates are merged
+- [ ] (If in-app hint is implemented) Language picker displays correctly with new labels
+- [ ] (If in-app hint is implemented) Arabic RTL layout still displays correctly
+- [ ] PR created with summary, linking to this proposal

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,48 @@
+# FlintWave Flash — Project Context
+
+## Purpose
+
+Cross-platform (Linux/Windows/macOS) wxPython GUI for flashing firmware to
+handheld radios that use the KDH bootloader (`.kdhx` firmware) or the BTF
+protocol (`.BTF`, Radtel RT-950 Pro). Downloads vendor firmware bundles,
+verifies them, and drives the serial flash protocol, with a multilingual UI
+(8 languages, RTL support).
+
+## Tech stack
+
+- Python 3.12, wxPython 4.2 (GUI), pyserial (radio I/O), requests (downloads)
+- No package manager manifest — stdlib + the four deps above; PyInstaller builds
+- Tests: single `tests.py`, stdlib `unittest` (~160 tests). GUI tests skip
+  headless and run in CI. `mock_bootloader.py` emulates a strict KDH/BTF radio
+  for end-to-end protocol tests without hardware.
+- CI: `.github/workflows/tests.yml` (push/PR), `build-release.yml` (on `v*`
+  tags → AppImage/deb/rpm/exe/dmg via PyInstaller + fpm/Inno/dmgbuild)
+
+## Conventions
+
+- Radio definitions live in `radios.json` (English source of truth);
+  per-radio strings are translated in `translations/<code>.json` keyed
+  `radio.<id>.<field>`. Tests enforce translation completeness and reject
+  English-echo "translations".
+- `firmware_manifest.json` is fetched remotely from master by released
+  clients (raw.githubusercontent.com) to discover new firmware without an app
+  update; keyed by radio id — ids are a compatibility surface.
+- GUI decomposition in progress: `gui_main.py` (FlasherFrame, ~1,800 lines)
+  is being split into components (`gui_titlebar`, `gui_statusbar`,
+  `gui_columns`, `gui_workflow`, `gui_handset`, `gui_dialogs`, `gui_themes`).
+  Construction and behavior move out; the frame keeps thin delegators so
+  worker-thread call sites don't churn.
+- Changes touching threads + serial + live widgets need a hardware test
+  before merge (see PR #19's checklist pattern); protocol logic must be
+  testable headlessly (injectable dependencies, pure helpers).
+- Versioning: CalVer `vYY.MM.patch` (e.g. v26.07.0). `CHANGELOG.md` section
+  per release. Squash merges titled "<summary> (#PR)".
+
+## Domain notes
+
+- Vendors silently repack bundles at unchanged URLs and ship multiple
+  hardware-variant firmware files that are NOT interchangeable (BF-F8HP Pro
+  NRF/NRFB; RT-490 old/new PCB). Flashing the wrong variant can brick a
+  radio. Treat firmware selection as safety-critical.
+- Many `radios.json` entries are `tested: false` — community test reports
+  (GitHub issues) are how entries get confirmed.


### PR DESCRIPTION
## Summary

Initializes `openspec/` and adds change proposals for the roadmap agreed in-session, written by a parallel agent team (models matched to each item's design weight) and then reviewed/normalized. Docs only — no code changes.

| Change | Design core |
|---|---|
| `generalize-hardware-variants` | Sibling entries linked by `variant_group` + guided identification UX; preserves shipped radio ids (remote-manifest + translation compatibility). "I'm not sure" is a safe stop. |
| `pin-firmware-hashes` | Pin the 3 remaining unpinned bundles; test gate so future entries can't ship unpinned. |
| `decompose-gui-main-workers` | Three slices: gui_hints (low risk) → gui_download (medium) → gui_flash (high, hardware-gated; converges the hand-rolled serial paths onto the mock-testable drivers). |
| `one-click-test-reports` | The post-flash report dialog exists (produced #20) — fix repeat-flash nagging via state.json suppression, extract pure URL/body builders, document the tested-flag flip convention. |
| `translation-review-process` | Per-language tracking issues, CONTRIBUTING.md, whole-catalog `_meta.reviewed`, safety-critical strings first. |
| `ci-hardening` | 3-OS test matrix (reusing release-workflow install recipes), actionlint (no overlap with CodeQL's actions analysis — verified), weekly manifest-drift check that files/dedupes issues. |

Implementation follows as separate PRs per change, in order: pin-firmware-hashes → generalize-hardware-variants → ci-hardening → one-click-test-reports → translation-review-process → decompose-gui-main-workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD