### PR TITLE
Pin SHA-256 hashes for all firmware downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Firmware integrity
+
+- **All firmware downloads are now SHA-256 pinned.** `uv-25-pro`, `rt-470`, and `rt-490` had null hashes in the manifest — the blind spot that let the 2026-07-10 silent bundle repack go undetected. All three bundles were downloaded, their contents verified, and their hashes pinned; a new manifest-schema test blocks any future entry from shipping with a `firmware_url` but no hash.
+- **UV-25 Plus/Pro firmware version corrected to V0.23.** Verification caught another silent vendor swap: the bundle at the (unchanged) manifest URL actually contains `UV25Pro_NRF_401+_V0.23`, not the V0.20 the manifest claimed. Released clients will now correctly see V0.23 as the latest.
+- Known issue surfaced during verification: the RT-490 bundle ships **4** hardware-variant firmware files (GPS/NoGPS × HW V1.0/V2.0). Since the multi-match guard shipped in v26.07.0, that download fails safely instead of silently flashing the first file; proper variant selection lands with the `generalize-hardware-variants` change (see `openspec/changes/`).
+
 ## v26.07.0 — 2026-07-17
 
 ### Firmware download

--- a/firmware_manifest.json
+++ b/firmware_manifest.json
@@ -16,22 +16,22 @@
       "release_notes": "V0.53: smarter scanning, better airband, more control (NRFB hardware)"
     },
     "uv-25-pro": {
-      "firmware_version": "0.20",
+      "firmware_version": "0.23",
       "firmware_url": "https://baofeng.s3.amazonaws.com/Baofeng_UV-25_Plus_Firware_Update_Guide_20250526.zip",
-      "firmware_sha256": null,
-      "release_notes": "V0.20: fixed GPS radar distance display after location sharing"
+      "firmware_sha256": "60f25178ad65fb91ec381f841c02b3a2fc0fc5f8861412fef2788b0dc4305179",
+      "release_notes": "V0.23: current vendor bundle (UV25Pro_NRF_401+_V0.23, 2025-05-22 build; bundle URL unchanged since V0.20)"
     },
     "rt-470": {
       "firmware_version": "2.13C",
       "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/RT-470_RT470X_RT470L_NEW_PCB_8.33KHZ_V2.13C_20240425.rar",
-      "firmware_sha256": null,
+      "firmware_sha256": "35c6f69d617c371b3042c10ec414278f7c5e430f5c255558ec7d1f6cc9f76fef",
       "release_notes": "V2.13C: AM/FM modulation switch 18MHz-1000MHz, 8.33kHz air band (470X/470/470L, new PCB)"
     },
     "rt-490": {
       "firmware_version": "1.03",
       "firmware_url": "https://cdn.shopify.com/s/files/1/0564/8855/8800/files/Firmware_Version_1.03.zip",
-      "firmware_sha256": null,
-      "release_notes": "V1.03: old PCB firmware"
+      "firmware_sha256": "5b6bd65b8fd2754fb2c45b7e8a2db4133b9fedbf68c799f632968ab7d98e32bb",
+      "release_notes": "V1.03: old PCB firmware. Bundle ships 4 hardware-variant files (GPS/NoGPS x HW V1.0/V2.0); variant selection is pending the generalize-hardware-variants change"
     },
     "rt-490-new": {
       "firmware_version": "1.25a",

--- a/tests.py
+++ b/tests.py
@@ -933,6 +933,26 @@ class TestManifestSchema(unittest.TestCase):
             self.assertIn(radio["id"], manifest_ids,
                           f"Radio {radio['id']} missing from manifest")
 
+    def test_all_entries_with_url_must_have_hash(self):
+        """Every manifest entry with a firmware_url must pin a SHA-256.
+
+        Null hashes are the blind spot that let a vendor silently repack a
+        bundle at an unchanged URL undetected (2026-07-10 BaofengTech
+        incident). This gate keeps future entries from shipping unpinned.
+        """
+        for radio_id, info in self.manifest["radios"].items():
+            if not info.get("firmware_url"):
+                continue
+            sha = info.get("firmware_sha256")
+            self.assertIsInstance(
+                sha, str,
+                f"Radio {radio_id} has firmware_url but no firmware_sha256 — "
+                f"download the bundle, verify its contents, and pin the hash")
+            self.assertRegex(
+                sha, r"^[0-9a-f]{64}$",
+                f"Radio {radio_id} firmware_sha256 is not a lowercase "
+                f"hex SHA-256")
+
     def test_manifest_urls_are_valid(self):
         import firmware_download as dl
         for radio_id, info in self.manifest["radios"].items():


### PR DESCRIPTION
## Summary

Implements [`openspec/changes/pin-firmware-hashes`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/pin-firmware-hashes/proposal.md). All three unpinned manifest entries (`uv-25-pro`, `rt-470`, `rt-490`) now carry verified SHA-256 pins, and a new `TestManifestSchema.test_all_entries_with_url_must_have_hash` gate blocks future unpinned entries. 163 tests pass.

Each bundle was downloaded from its manifest URL and its `.kdhx` contents inspected before pinning. That verification surfaced two real findings:

1. **UV-25 version was stale.** The bundle at the unchanged URL contains `UV25Pro_NRF_401+_V0.23_250522.kdhx` — V0.23, not the manifest's claimed V0.20. Another silent vendor swap, caught by exactly the process this change mandates. Version corrected; released clients (which fetch this manifest from master) will now correctly offer V0.23.
2. **RT-490's bundle ships 4 hardware-variant files** (GPS/NoGPS × HW V1.0/V2.0). Since v26.07.0's multi-match guard, this download fails safely (naming the files) rather than silently flashing the first — but it *fails*, and there are no per-variant radio entries to direct the user to yet. That resolution is owned by `generalize-hardware-variants` (next up); noted in the manifest `release_notes` and CHANGELOG meanwhile.

## Notes for reviewers

- Merging this activates hash verification for **released** clients too (they fetch the manifest from master raw). A future vendor repack will surface as an explicit hash-mismatch error instead of silent breakage — that's the intent; the fix path is re-verify + update the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD