### PR TITLE
CI hardening: 3-OS test matrix, actionlint, weekly manifest-drift check

### DIFF
--- a/.github/scripts/check_manifest_drift.py
+++ b/.github/scripts/check_manifest_drift.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Weekly manifest-drift check (.github/workflows/manifest-drift.yml).
+
+Downloads every firmware bundle that firmware_manifest.json pins
+(non-null firmware_url AND non-null firmware_sha256) and compares the
+actual SHA-256 against the pinned value. Vendors are known to silently
+repack bundles at unchanged URLs (2026-07-10 BaofengTech incident);
+this catches that within a week instead of when a user hits it.
+
+Distinguishes three outcomes and never conflates them:
+- drifted:    downloaded fine, hash differs  -> the workflow files an issue
+- unverified: download failed after retries  -> job-summary note only,
+              NEVER reported as drift (vendor CDNs are flaky)
+- ok:         hash matches                   -> used to auto-close a
+              previously filed drift issue
+
+Entries are checked sequentially with a pause between them so vendor
+servers are not hammered. Writes drift_result.json for the issue-lifecycle
+step and prints a Markdown summary to stdout (piped to $GITHUB_STEP_SUMMARY).
+Exit code is always 0 unless the manifest itself is unreadable — drift is
+reported through issues, not a red scheduled run nobody looks at.
+"""
+
+import hashlib
+import json
+import sys
+import time
+import urllib.request
+
+USER_AGENT = (
+    "flintwave-flash-drift-check/1.0 "
+    "(+https://github.com/FlintWave/flintwave-kdh-flasher)"
+)
+TIMEOUT = 120       # per-download seconds
+RETRIES = 3
+PAUSE_BETWEEN = 2   # seconds between entries — be gentle to vendor servers
+
+
+def fetch_sha256(url):
+    """Stream-download url and return (hexdigest, None), or (None, error)."""
+    last_err = "unknown error"
+    for attempt in range(RETRIES):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            digest = hashlib.sha256()
+            with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+                for chunk in iter(lambda: resp.read(65536), b""):
+                    digest.update(chunk)
+            return digest.hexdigest(), None
+        except Exception as exc:  # noqa: BLE001 - any failure is "unverified"
+            last_err = f"{type(exc).__name__}: {exc}"
+            time.sleep(5 * (attempt + 1))
+    return None, last_err
+
+
+def main():
+    with open("firmware_manifest.json", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    drifted, unverified, ok, skipped = [], [], [], []
+    for radio_id, info in sorted(manifest["radios"].items()):
+        url = info.get("firmware_url")
+        pinned = info.get("firmware_sha256")
+        if not url or not pinned:
+            skipped.append(radio_id)
+            continue
+        actual, err = fetch_sha256(url)
+        if actual is None:
+            unverified.append({"id": radio_id, "url": url, "error": err})
+        elif actual != pinned:
+            drifted.append({
+                "id": radio_id, "url": url,
+                "expected": pinned, "actual": actual,
+            })
+        else:
+            ok.append(radio_id)
+        time.sleep(PAUSE_BETWEEN)
+
+    with open("drift_result.json", "w", encoding="utf-8") as f:
+        json.dump({"drifted": drifted, "unverified": unverified,
+                   "ok": ok, "skipped": skipped}, f, indent=2)
+
+    print("## Manifest drift check")
+    print()
+    if drifted:
+        print(f"### DRIFT DETECTED ({len(drifted)})")
+        for d in drifted:
+            print(f"- **{d['id']}** — expected `{d['expected']}`, "
+                  f"got `{d['actual']}` ({d['url']})")
+        print()
+    if unverified:
+        print(f"### Could not verify ({len(unverified)}) — "
+              "download failed, NOT reported as drift")
+        for u in unverified:
+            print(f"- **{u['id']}** — {u['error']} ({u['url']})")
+        print()
+    print(f"OK: {len(ok)} ({', '.join(ok) or '—'}); "
+          f"skipped (no url or no pin): {len(skipped)} "
+          f"({', '.join(skipped) or '—'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,27 @@
+name: Lint Workflows
+
+# Schema, expression, and shellcheck-level linting of the workflow files
+# themselves. This is intentionally separate from and non-duplicative of the
+# CodeQL "Analyze (actions)" job: CodeQL's actions analysis is a security
+# scan (untrusted-input flows, script injection, excessive permissions) and
+# does not validate workflow syntax, expression types, matrix/needs
+# references, or shell correctness — actionlint does.
+on:
+  push:
+    branches: [master]
+    paths: ['.github/workflows/**']
+  pull_request:
+    paths: ['.github/workflows/**']
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -223,7 +223,7 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
-          ASSETS=""
+          ASSETS=()
           for f in \
             linux-packages/FlintWave-Flash-x86_64.AppImage \
             linux-packages/*.deb \
@@ -232,7 +232,7 @@ jobs:
             windows-packages/dist/FlintWave-Flash.exe \
             macos-packages/FlintWave-Flash.dmg \
           ; do
-            [ -f "$f" ] && ASSETS="$ASSETS $f"
+            [ -f "$f" ] && ASSETS+=("$f")
           done
           # Idempotent: if a previous workflow run already published this tag
           # (e.g. duplicate trigger, manual re-run, or the concurrency block
@@ -240,7 +240,7 @@ jobs:
           # place instead of failing with "release already exists".
           if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG_NAME exists; uploading assets with --clobber"
-            gh release upload "$TAG_NAME" $ASSETS \
+            gh release upload "$TAG_NAME" "${ASSETS[@]}" \
               --repo "$GITHUB_REPOSITORY" \
               --clobber
           else
@@ -248,5 +248,5 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "$TAG_NAME" \
               --generate-notes \
-              $ASSETS
+              "${ASSETS[@]}"
           fi

--- a/.github/workflows/manifest-drift.yml
+++ b/.github/workflows/manifest-drift.yml
@@ -1,0 +1,87 @@
+name: Manifest Drift Check
+
+# Weekly check that every pinned firmware bundle in firmware_manifest.json
+# still hashes to its pinned SHA-256. Vendors silently repack bundles at
+# unchanged URLs (2026-07-10 BaofengTech incident went undetected for a
+# week); this surfaces that as a labeled issue within a week instead.
+#
+# Coverage tracks the manifest dynamically: every entry with both a
+# firmware_url and a firmware_sha256 is checked (all URL-bearing entries
+# are pinned as of the pin-firmware-hashes change, and a test gate keeps
+# it that way). "Download failed" is reported in the job summary only and
+# never as drift — vendor CDNs are flaky and a transient failure is not a
+# repack.
+on:
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays 06:17 UTC; odd minute avoids load spikes
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: manifest-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check pinned bundles for drift
+        run: python3 .github/scripts/check_manifest_drift.py | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: File, update, or close drift issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create firmware-drift \
+            --repo "$REPO" \
+            --color D93F0B \
+            --description "A pinned firmware bundle changed at its vendor URL" \
+            2>/dev/null || true
+
+          open_issue_for() {
+            gh issue list --repo "$REPO" \
+              --search "\"Firmware drift: $1\" in:title" \
+              --label firmware-drift --state open \
+              --json number --jq '.[0].number // empty'
+          }
+
+          # Verified drift: file a new issue or comment on the open one.
+          jq -c '.drifted[]' drift_result.json | while read -r row; do
+            rid=$(jq -r '.id' <<<"$row")
+            url=$(jq -r '.url' <<<"$row")
+            expected=$(jq -r '.expected' <<<"$row")
+            actual=$(jq -r '.actual' <<<"$row")
+            # Backticks in the body are markdown code spans, not command
+            # substitution — the format string is intentionally single-quoted.
+            # shellcheck disable=SC2016
+            body=$(printf 'The pinned bundle for `%s` no longer matches.\n\n- URL: %s\n- Expected SHA-256: `%s`\n- Actual SHA-256: `%s`\n- Detected by: %s\n\nNext step: download the bundle, verify its contents are legitimate (see openspec/changes/pin-firmware-hashes), then update the pin in `firmware_manifest.json` — or investigate if the change looks like tampering. Released clients are protected meanwhile: their downloads fail with an explicit hash mismatch.' \
+              "$rid" "$url" "$expected" "$actual" "$RUN_URL")
+            existing=$(open_issue_for "$rid")
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" --body "Still drifted as of the latest check.
+
+          $body"
+            else
+              gh issue create --repo "$REPO" \
+                --title "Firmware drift: $rid" \
+                --label firmware-drift \
+                --body "$body"
+            fi
+          done
+
+          # Recovery: a previously drifted entry matches again (pin was
+          # updated or the vendor restored the original) — close its issue.
+          jq -r '.ok[]' drift_result.json | while read -r rid; do
+            existing=$(open_issue_for "$rid")
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$REPO" \
+                --comment "The bundle for \`$rid\` matches its manifest pin again as of the latest check ($RUN_URL). Closing."
+            fi
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,22 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      # One flaky OS leg must not mask results from the others.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
-      # Use the system Python (3.12 on ubuntu-latest) together with the
+      # Linux uses the system Python (3.12 on ubuntu-latest) together with the
       # apt-packaged dependencies — this mirrors the project's documented
       # Linux install path (README) and avoids the setup-python / apt-wxPython
       # interpreter mismatch. With wxPython, pyserial, and requests all present
       # the GUI/theme/i18n tests actually run instead of self-skipping.
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -33,12 +39,34 @@ jobs:
             python3-requests \
             xvfb
 
+      # Windows/macOS mirror the release build's install path (build-release.yml):
+      # setup-python + pip wheels.
+      - name: Set up Python (Windows/macOS)
+        if: runner.os != 'Linux'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies (Windows/macOS)
+        if: runner.os != 'Linux'
+        run: python -m pip install pyserial requests wxPython --prefer-binary
+
+      # A broken wx install should fail here with one clear message, not as a
+      # wall of skipped-test noise later.
       - name: Show environment
+        shell: bash
         run: |
-          python3 --version
-          python3 -c "import wx, serial, requests; print('wx', wx.__version__)"
+          if [ "$RUNNER_OS" = "Linux" ]; then PY=python3; else PY=python; fi
+          "$PY" --version
+          "$PY" -c "import wx, serial, requests; print('wx', wx.__version__)"
 
       # gui_themes / gui_main import wx.adv, so a display must exist even to
-      # import them; xvfb-run supplies a headless one.
-      - name: Run test suite
+      # import them; xvfb-run supplies a headless one on Linux. Windows and
+      # macOS runners already have a display server.
+      - name: Run test suite (Linux)
+        if: runner.os == 'Linux'
         run: xvfb-run -a python3 tests.py
+
+      - name: Run test suite (Windows/macOS)
+        if: runner.os != 'Linux'
+        run: python tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Build / CI
+
+- **Tests now run on Linux, Windows, and macOS.** The test workflow gained an OS matrix (`fail-fast: false`); Windows/macOS legs reuse the release build's setup-python + pip-wheel install path, so the wx GUI tests execute on the platforms most users run instead of Linux-only.
+- **Workflow linting.** An `actionlint` job now checks `.github/workflows/**` on every change — intentionally complementary to CodeQL's security-focused actions analysis. Its first run caught two unquoted-expansion bugs in the release script's asset handling (now fixed with a bash array).
+- **Weekly firmware-drift check.** A scheduled workflow re-downloads every pinned bundle and compares hashes, filing/updating a `firmware-drift` issue on verified drift and auto-closing it on recovery. Download failures are reported in the job summary but never as drift. This would have caught the 2026-07-10 silent repack within the week.
+
 ### Firmware integrity
 
 - **All firmware downloads are now SHA-256 pinned.** `uv-25-pro`, `rt-470`, and `rt-490` had null hashes in the manifest — the blind spot that let the 2026-07-10 silent bundle repack go undetected. All three bundles were downloaded, their contents verified, and their hashes pinned; a new manifest-schema test blocks any future entry from shipping with a `firmware_url` but no hash.


### PR DESCRIPTION
## Summary

Implements [`openspec/changes/ci-hardening`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/ci-hardening/proposal.md), all three groups:

1. **3-OS test matrix** — `tests.yml` runs on ubuntu/windows/macos (`fail-fast: false`). Windows/macOS reuse the release workflow's setup-python + pip-wheel install path; Linux keeps the documented apt + xvfb path. The environment sanity step fails fast with one clear message if wx doesn't import. **This PR's own CI run is the first matrix run** — per the proposal, observe the Windows/macOS legs here before merge (wxPython wheel installs are the flake risk).
2. **actionlint** — path-scoped workflow-lint job, complementary to CodeQL's security-focused actions analysis (no overlap — verified in the proposal's design doc). Ran locally as a smoke test: it found **two real unquoted-expansion bugs (SC2086) in the release script's asset handling**, fixed here by switching `ASSETS` to a bash array — behavior identical, word-splitting now explicit.
3. **Manifest drift check** — weekly cron + `workflow_dispatch`, `.github/scripts/check_manifest_drift.py`. Sequential downloads (gentle on vendor CDNs), retry/backoff, descriptive User-Agent. Verified drift files/updates a `firmware-drift` issue per radio and auto-closes on recovery; download failures go to the job summary only and are **never** reported as drift. Smoke-tested against the live master manifest: all 5 pinned entries verify OK, `rt-490-new` (null URL) correctly skipped.

## Follow-up after merge

- Trigger one manual `workflow_dispatch` run of Manifest Drift Check to exercise the issue-lifecycle path in CI (expected: no issues filed, green summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD