### PR TITLE
One-click test reports: suppression memory and testable builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Test reports
+
+- **The post-flash test-report offer no longer nags.** A new "don't ask again for this radio + firmware version" checkbox suppresses the prompt per (radio, version) — recorded in the state file — while a plain Skip keeps asking next time, and a new firmware version re-opens the offer. The report URL/body builders were extracted from the dialog into pure functions with real tests (URL-length budget included), replacing tests that re-derived the logic by hand. Reports keep the `test-report` label + `Radio:` body-line convention maintainers use to flip `tested` flags.
+
 ### Hardware variants
 
 - **Guided hardware-variant identification.** Radios that ship as non-interchangeable hardware versions behind one vendor bundle (BTECH BF-F8HP Pro NRF/NRFB, Radtel RT-490 old/new PCB) now appear as a single family row in the radio picker. Selecting the family walks the user through identifying their version (e.g. "radio off, hold 8 while powering on") with one option per variant and an explicit "I'm not sure" that fails safe — Download stays disabled with a link to the vendor page instead of risking a wrong-variant flash. Fully translated in all 7 catalogs; radio ids, the remote manifest shape, and the post-download multi-match guard are unchanged, so released clients are unaffected.

--- a/firmware_manifest.py
+++ b/firmware_manifest.py
@@ -257,6 +257,40 @@ def get_last_flashed(radio_id):
     return state.get("last_flashed", {}).get(radio_id)
 
 
+# Sentinel firmware version used when the version can't be parsed from the
+# filename, so nag suppression degrades to keying on radio id alone instead of
+# crashing or never suppressing.
+TEST_REPORT_UNKNOWN_VERSION = "unknown"
+
+
+def mark_test_report(radio_id, version, status):
+    """Record that a community test report was submitted or explicitly skipped.
+
+    Keyed by (radio id, firmware version); `status` is "submitted" or
+    "skipped". A falsy version falls back to a sentinel so suppression still
+    works for firmware whose version can't be parsed from the filename.
+    """
+    version = version or TEST_REPORT_UNKNOWN_VERSION
+    state = _load_state()
+    if "test_reports" not in state:
+        state["test_reports"] = {}
+    if radio_id not in state["test_reports"]:
+        state["test_reports"][radio_id] = {}
+    state["test_reports"][radio_id][version] = status
+    _save_state(state)
+
+
+def get_test_report_status(radio_id, version):
+    """Return the stored test-report status for a radio+version, or None.
+
+    Uses the same falsy-version fallback as mark_test_report so a lookup and a
+    write for an unparseable version resolve to the same sentinel key.
+    """
+    version = version or TEST_REPORT_UNKNOWN_VERSION
+    state = _load_state()
+    return state.get("test_reports", {}).get(radio_id, {}).get(version)
+
+
 def get_language(default="en"):
     """Return the persisted UI language code, or the default if none stored."""
     state = _load_state()

--- a/gui_dialogs.py
+++ b/gui_dialogs.py
@@ -8,11 +8,81 @@ have been removed.
 """
 
 import os
+import platform
+import urllib.parse
+
 import wx
 import wx.adv
 
 from gui_themes import apply_theme_to_dialog
 from i18n import t, is_rtl
+
+# Base URL and label for the community test-report GitHub issue. The
+# maintainer-side triage convention keys off this exact `test-report` label
+# plus the `Radio:` line that build_report_body() emits as the body's first
+# line (see openspec/changes/one-click-test-reports/design.md).
+REPORT_ISSUE_URL = "https://github.com/FlintWave/flintwave-kdh-flasher/issues/new"
+REPORT_LABEL = "test-report"
+
+# The in-app log is truncated to its last N characters before it goes into the
+# report body. Percent-encoding can expand each character up to ~3x (a newline
+# becomes "%0A"), so this cap is chosen to keep the fully encoded issues/new URL
+# comfortably under the ~8000-char practical browser/GitHub ceiling even for a
+# worst-case log. TestReportURLs.test_url_length_budget guards this.
+LOG_TRUNCATE_CHARS = 2000
+
+
+def build_report_subject(radio_name, success):
+    """Build the GitHub issue title for a flash report. No wx dependency."""
+    status = (t("dialog.report.result_success") if success
+              else t("dialog.report.result_failure"))
+    return t("dialog.report.subject").format(radio=radio_name, status=status)
+
+
+def build_report_body(radio_name, firmware_path, success, error_msg,
+                      log_content=""):
+    """Build the prefilled GitHub issue body for a flash report.
+
+    Pure string construction with no wx dependency so it is unit-testable
+    without a display. Includes, in order: radio name, firmware basename,
+    result, OS name/release, Python version, the error message (on failure),
+    an additional-notes placeholder, and (if a log was captured) the last
+    LOG_TRUNCATE_CHARS characters of the in-app log under a log header.
+    """
+    status = (t("dialog.report.result_success") if success
+              else t("dialog.report.result_failure"))
+    fw_file = os.path.basename(firmware_path) if firmware_path else "unknown"
+
+    report_body = (
+        t("dialog.report.body_radio").format(radio=radio_name)
+        + t("dialog.report.body_firmware").format(firmware=fw_file)
+        + t("dialog.report.body_result").format(status=status)
+        + t("dialog.report.body_os").format(
+            os=f"{platform.system()} {platform.release()}")
+        + t("dialog.report.body_python").format(python=platform.python_version())
+    )
+    if error_msg:
+        report_body += t("dialog.report.body_error").format(error=error_msg)
+    report_body += t("dialog.report.body_notes")
+    if log_content:
+        # Truncate log to last LOG_TRUNCATE_CHARS chars to keep URL manageable
+        truncated = (log_content[-LOG_TRUNCATE_CHARS:]
+                     if len(log_content) > LOG_TRUNCATE_CHARS else log_content)
+        report_body += t("dialog.report.body_log_header") + truncated + "\n"
+    return report_body
+
+
+def build_report_url(title, body):
+    """Build the full GitHub issues/new URL with title/body/labels prefilled.
+
+    urlencode percent-escapes special characters (`<`, `>`, `"`, `&`, newlines,
+    ...) so the returned URL never carries them raw. No wx dependency.
+    """
+    return REPORT_ISSUE_URL + "?" + urllib.parse.urlencode({
+        "title": title,
+        "body": body,
+        "labels": REPORT_LABEL,
+    })
 
 
 def _apply_direction(window):
@@ -129,30 +199,18 @@ def show_about_dialog(frame):
 
 
 def show_test_report_dialog(frame, radio_name, firmware_path, success, error_msg, log_content=""):
-    """Show the test report submission dialog after a flash attempt."""
-    import platform
-    import urllib.parse
+    """Show the test report submission dialog after a flash attempt.
 
-    status = t("dialog.report.result_success") if success else t("dialog.report.result_failure")
-    fw_file = os.path.basename(firmware_path) if firmware_path else "unknown"
-
-    report_body = (
-        t("dialog.report.body_radio").format(radio=radio_name)
-        + t("dialog.report.body_firmware").format(firmware=fw_file)
-        + t("dialog.report.body_result").format(status=status)
-        + t("dialog.report.body_os").format(
-            os=f"{platform.system()} {platform.release()}")
-        + t("dialog.report.body_python").format(python=platform.python_version())
-    )
-    if error_msg:
-        report_body += t("dialog.report.body_error").format(error=error_msg)
-    report_body += t("dialog.report.body_notes")
-    if log_content:
-        # Truncate log to last 2000 chars to keep URL manageable
-        truncated = log_content[-2000:] if len(log_content) > 2000 else log_content
-        report_body += t("dialog.report.body_log_header") + truncated + "\n"
-
-    subject = t("dialog.report.subject").format(radio=radio_name, status=status)
+    Returns the nag-suppression status the caller should persist for this
+    radio+firmware combination:
+      - "submitted" — the user clicked Submit (a submitted report always
+        suppresses future offers).
+      - "skipped"   — the user dismissed with "don't ask again" checked.
+      - None        — a plain Skip, which must NOT suppress future offers.
+    """
+    report_body = build_report_body(radio_name, firmware_path, success,
+                                    error_msg, log_content)
+    subject = build_report_subject(radio_name, success)
 
     dlg = wx.Dialog(frame, title=t("dialog.report.title"), size=(520, 500))
     dlg.SetMinSize((480, 400))
@@ -186,19 +244,21 @@ def show_test_report_dialog(frame, radio_name, firmware_path, success, error_msg
 
     sizer.AddSpacer(10)
 
+    # Explicit, opt-in suppression. Distinct from the Skip button: a plain
+    # Skip keeps prompting on future flashes, only this checkbox persists a
+    # "skipped" record for this radio+firmware.
+    dont_ask = wx.CheckBox(dlg, label=t("dialog.report.dont_ask_again"))
+    dont_ask.SetFont(ui_font)
+    sizer.Add(dont_ask, 0, wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, 15)
+
+    sizer.AddSpacer(10)
+
     btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
     submit_btn = wx.Button(dlg, label=t("button.submit"))
     submit_btn.SetFont(ui_font)
     submit_btn.Bind(wx.EVT_BUTTON, lambda e: (
-        wx.LaunchDefaultBrowser(
-            "https://github.com/FlintWave/flintwave-kdh-flasher/issues/new?"
-            + urllib.parse.urlencode({
-                "title": subject,
-                "body": preview.GetValue(),
-                "labels": "test-report"
-            })
-        ),
+        wx.LaunchDefaultBrowser(build_report_url(subject, preview.GetValue())),
         dlg.EndModal(wx.ID_OK)
     ))
     btn_sizer.Add(submit_btn, 0, wx.RIGHT, 8)
@@ -218,5 +278,14 @@ def show_test_report_dialog(frame, radio_name, firmware_path, success, error_msg
         hint.SetOwnForegroundColour(wx.Colour(*palette[4]))  # subtext1
 
     dlg.Centre()
-    dlg.ShowModal()
+    result = dlg.ShowModal()
+    # Read the checkbox before destroying the dialog. Submit always suppresses;
+    # a Skip only suppresses when "don't ask again" was checked.
+    if result == wx.ID_OK:
+        status = "submitted"
+    elif dont_ask.GetValue():
+        status = "skipped"
+    else:
+        status = None
     dlg.Destroy()
+    return status

--- a/gui_main.py
+++ b/gui_main.py
@@ -1788,6 +1788,9 @@ class FlasherFrame(wx.Frame):
             try:
                 fm.mark_test_report(radio_id, file_version, status)
             except Exception:
+                # Recording the suppression state is best-effort: a corrupt or
+                # unwritable state file must not turn a successful flash into
+                # an error dialog. Worst case the user is asked again next time.
                 pass
         if success:
             self._offer_firmware_cleanup(firmware_path)

--- a/gui_main.py
+++ b/gui_main.py
@@ -1563,6 +1563,12 @@ class FlasherFrame(wx.Frame):
         if (radio or {}).get("protocol") == "btf":
             return self._flash_thread_btf(port, firmware_path, handset_idx, radio)
 
+        # Derive once, up front, so both the success and failure paths pass the
+        # same identity to record_flash and to the test-report nag suppression.
+        radio_id = radio["id"] if radio else None
+        file_version = fv.extract_version_from_filename(
+            os.path.basename(firmware_path))
+
         if handset_idx is not None:
             wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FLASHING)
             wx.CallAfter(self._set_handset_progress, handset_idx, "0%")
@@ -1632,7 +1638,6 @@ class FlasherFrame(wx.Frame):
                 wx.CallAfter(self._set_handset_progress, handset_idx, "100%")
 
             # Record flash version
-            file_version = fv.extract_version_from_filename(os.path.basename(firmware_path))
             if radio and file_version:
                 try:
                     fm.record_flash(radio["id"], file_version, sha256)
@@ -1651,7 +1656,8 @@ class FlasherFrame(wx.Frame):
                             latest=latest_ver, current=file_version))
 
             self._terminal_state = "complete"
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path, True, "")
+            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
+                         True, "", radio_id, file_version)
 
         except Exception as e:
             error_msg = str(e)
@@ -1664,7 +1670,8 @@ class FlasherFrame(wx.Frame):
             if handset_idx is not None:
                 wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FAILED)
                 wx.CallAfter(self._set_handset_progress, handset_idx, "—")
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path, False, error_msg)
+            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
+                         False, error_msg, radio_id, file_version)
         finally:
             self._busy = False
             self.set_buttons(True)
@@ -1674,6 +1681,11 @@ class FlasherFrame(wx.Frame):
         # per-handset status, log messages, post-flash version recording, test
         # report offer) but delegates the on-the-wire work to fw_btf.
         radio_name = radio["name"] if radio else t("fallback.radio_unknown")
+        # Derive once, up front, so both the success and failure paths pass the
+        # same identity to record_flash and to the test-report nag suppression.
+        radio_id = radio["id"] if radio else None
+        file_version = fv.extract_version_from_filename(
+            os.path.basename(firmware_path))
         if handset_idx is not None:
             wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FLASHING)
             wx.CallAfter(self._set_handset_progress, handset_idx, "0%")
@@ -1712,7 +1724,6 @@ class FlasherFrame(wx.Frame):
                 wx.CallAfter(self._set_handset_status, handset_idx, STATUS_DONE)
                 wx.CallAfter(self._set_handset_progress, handset_idx, "100%")
 
-            file_version = fv.extract_version_from_filename(os.path.basename(firmware_path))
             if radio and file_version:
                 try:
                     fm.record_flash(radio["id"], file_version, sha256)
@@ -1722,7 +1733,8 @@ class FlasherFrame(wx.Frame):
                     pass
 
             self._terminal_state = "complete"
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path, True, "")
+            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
+                         True, "", radio_id, file_version)
 
         except Exception as e:
             error_msg = str(e)
@@ -1735,7 +1747,8 @@ class FlasherFrame(wx.Frame):
             if handset_idx is not None:
                 wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FAILED)
                 wx.CallAfter(self._set_handset_progress, handset_idx, "—")
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path, False, error_msg)
+            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
+                         False, error_msg, radio_id, file_version)
         finally:
             self._busy = False
             self.set_buttons(True)
@@ -1756,9 +1769,26 @@ class FlasherFrame(wx.Frame):
         self.log_msg(t("log.dialout_fix_cmd"))
         self.log_msg(t("log.dialout_relogin"))
 
-    def _offer_test_report(self, radio_name, firmware_path, success, error_msg):
+    def _offer_test_report(self, radio_name, firmware_path, success, error_msg,
+                           radio_id=None, file_version=None):
+        # Nag suppression: once a report was submitted or explicitly skipped for
+        # this radio id + firmware version, don't offer again for that same
+        # combination (keyed the same grain record_flash uses). A plain Skip
+        # does not record anything, so it keeps prompting on future flashes.
+        if radio_id and fm.get_test_report_status(radio_id, file_version) in (
+                "submitted", "skipped"):
+            if success:
+                self._offer_firmware_cleanup(firmware_path)
+            return
+
         log_content = self.log.GetValue()
-        show_test_report_dialog(self, radio_name, firmware_path, success, error_msg, log_content)
+        status = show_test_report_dialog(self, radio_name, firmware_path,
+                                         success, error_msg, log_content)
+        if radio_id and status:
+            try:
+                fm.mark_test_report(radio_id, file_version, status)
+            except Exception:
+                pass
         if success:
             self._offer_firmware_cleanup(firmware_path)
 

--- a/openspec/changes/one-click-test-reports/tasks.md
+++ b/openspec/changes/one-click-test-reports/tasks.md
@@ -2,60 +2,60 @@
 
 ## 1. Extract pure report-construction functions
 
-- [ ] 1.1 In `gui_dialogs.py`, extract the body-building logic currently
+- [x] 1.1 In `gui_dialogs.py`, extract the body-building logic currently
       inline in `show_test_report_dialog()` into a standalone function,
       e.g. `build_report_body(radio_name, firmware_path, success,
       error_msg, log_content)` — no `wx` references, returns a plain
       string.
-- [ ] 1.2 Extract the subject/title construction into a standalone
+- [x] 1.2 Extract the subject/title construction into a standalone
       function, e.g. `build_report_subject(radio_name, success)`.
-- [ ] 1.3 Extract the GitHub issue URL construction into a standalone
+- [x] 1.3 Extract the GitHub issue URL construction into a standalone
       function, e.g. `build_report_url(title, body)`, returning the full
       `https://github.com/.../issues/new?...` string.
-- [ ] 1.4 Update `show_test_report_dialog()` to call these three
+- [x] 1.4 Update `show_test_report_dialog()` to call these three
       functions instead of inlining the logic, keeping its own scope to
       widget construction and layout.
 
 ## 2. Nag-suppression state
 
-- [ ] 2.1 In `firmware_manifest.py`, add `mark_test_report(radio_id,
+- [x] 2.1 In `firmware_manifest.py`, add `mark_test_report(radio_id,
       version, status)` writing into a new top-level `test_reports` block
       in state (`state["test_reports"][radio_id][version] = status`),
       following the same load/mutate/`_save_state` pattern as
       `record_flash`.
-- [ ] 2.2 Add `get_test_report_status(radio_id, version)` returning the
+- [x] 2.2 Add `get_test_report_status(radio_id, version)` returning the
       stored status string or `None`, mirroring `get_last_flashed`.
-- [ ] 2.3 Define and use a fallback version sentinel (e.g. `"unknown"`)
+- [x] 2.3 Define and use a fallback version sentinel (e.g. `"unknown"`)
       when `file_version` is falsy, in both the mark and get paths, so
       suppression still works for firmware whose version can't be parsed
       from the filename.
 
 ## 3. Wire suppression into the flash-completion path
 
-- [ ] 3.1 In `gui_main.py`, before calling `show_test_report_dialog` from
+- [x] 3.1 In `gui_main.py`, before calling `show_test_report_dialog` from
       `_offer_test_report`, check `fm.get_test_report_status(radio["id"],
       file_version)`; if it is `"submitted"` or `"skipped"`, return
       without showing the dialog.
-- [ ] 3.2 Thread `file_version` (already computed earlier in
+- [x] 3.2 Thread `file_version` (already computed earlier in
       `_flash_thread`/`_flash_thread_btf` via
       `fv.extract_version_from_filename`) through to
       `_offer_test_report` so the same value used for `record_flash` is
       used for suppression lookups — avoid re-deriving it twice.
-- [ ] 3.3 Confirm both call sites (`_flash_thread` success/failure,
+- [x] 3.3 Confirm both call sites (`_flash_thread` success/failure,
       `_flash_thread_btf` success/failure) pass the radio dict and
       version through consistently.
 
 ## 4. "Don't ask again" affordance in the dialog
 
-- [ ] 4.1 Add a `wx.CheckBox` to the report dialog, unchecked by default,
+- [x] 4.1 Add a `wx.CheckBox` to the report dialog, unchecked by default,
       labeled via a new i18n key (see section 6).
-- [ ] 4.2 On Submit: always call `mark_test_report(radio_id, version,
+- [x] 4.2 On Submit: always call `mark_test_report(radio_id, version,
       "submitted")` regardless of the checkbox (a submitted report always
       suppresses future offers for that combination).
-- [ ] 4.3 On Skip: call `mark_test_report(radio_id, version, "skipped")`
+- [x] 4.3 On Skip: call `mark_test_report(radio_id, version, "skipped")`
       only if the checkbox is checked; otherwise leave state untouched so
       a plain Skip keeps prompting on future flashes.
-- [ ] 4.4 Pass `radio_id` and `version` into `show_test_report_dialog` (it
+- [x] 4.4 Pass `radio_id` and `version` into `show_test_report_dialog` (it
       currently takes `radio_name`, not the id) so it can call
       `mark_test_report` directly, or return the checkbox/button outcome
       to the caller for `_offer_test_report` to persist — pick whichever
@@ -65,11 +65,11 @@
 
 ## 5. URL length safety
 
-- [ ] 5.1 Add a test that builds a worst-case log tail (2000 characters,
+- [x] 5.1 Add a test that builds a worst-case log tail (2000 characters,
       all newlines or another maximally-expanding character) through
       `build_report_body` + `build_report_url` and asserts the resulting
       URL length stays under 8000 characters.
-- [ ] 5.2 If the worst case exceeds budget, reduce the raw log truncation
+- [x] 5.2 If the worst case exceeds budget, reduce the raw log truncation
       length (currently 2000 chars in `show_test_report_dialog`, now
       relocated into `build_report_body`) until it fits, and note the new
       constant.
@@ -78,30 +78,30 @@
    `TestRadioStringTranslations.REQUIRED_LANGS` — `zh-CN`, `fr`, `de`,
    `it`, `es`, `ar`, `ru`)
 
-- [ ] 6.1 Add `dialog.report.dont_ask_again` ("Don't ask again for this
+- [x] 6.1 Add `dialog.report.dont_ask_again` ("Don't ask again for this
       radio and firmware version" or equivalent) to `translations/en.json`.
-- [ ] 6.2 Add the same key, properly translated (not English-echoed), to
+- [x] 6.2 Add the same key, properly translated (not English-echoed), to
       `translations/zh-CN.json`, `fr.json`, `de.json`, `it.json`,
       `es.json`, `ar.json`, `ru.json`.
-- [ ] 6.3 Run/extend `tests.py`'s translation-completeness checks (pattern
+- [x] 6.3 Run/extend `tests.py`'s translation-completeness checks (pattern
       matches `TestRadioStringTranslations`) to also cover
       `dialog.report.*` keys across all 7 non-English catalogs, catching
       both missing keys and English-echoed values.
 
 ## 7. Tests
 
-- [ ] 7.1 Update `TestReportURLs` and `TestReportGeneration` in
+- [x] 7.1 Update `TestReportURLs` and `TestReportGeneration` in
       `tests.py` to call the real `build_report_body` /
       `build_report_subject` / `build_report_url` functions from
       `gui_dialogs` instead of re-deriving the logic inline.
-- [ ] 7.2 Add tests for `mark_test_report` / `get_test_report_status` in
+- [x] 7.2 Add tests for `mark_test_report` / `get_test_report_status` in
       `firmware_manifest.py`: fresh state returns `None`; marking
       `"submitted"` then querying returns `"submitted"`; a different
       version for the same radio id returns `None`; missing/falsy version
       uses the fallback sentinel consistently between mark and get.
-- [ ] 7.3 Add a test for the URL length budget (see 5.1) as a permanent
+- [x] 7.3 Add a test for the URL length budget (see 5.1) as a permanent
       regression guard.
-- [ ] 7.4 Add a GUI-level (or thin integration) test asserting
+- [x] 7.4 Add a GUI-level (or thin integration) test asserting
       `_offer_test_report` does not invoke `show_test_report_dialog` when
       `get_test_report_status` already returns a non-`None` value for the
       given radio+version — mock/monkeypatch the dialog call the way

--- a/tests.py
+++ b/tests.py
@@ -1444,12 +1444,14 @@ class TestDialogReportTranslations(unittest.TestCase):
 
     def setUp(self):
         repo = os.path.dirname(__file__)
-        self.en = json.load(
-            open(os.path.join(repo, "translations", "en.json"), encoding="utf-8"))
+        with open(os.path.join(repo, "translations", "en.json"),
+                  encoding="utf-8") as f:
+            self.en = json.load(f)
         self.catalogs = {}
         for code in self.REQUIRED_LANGS:
             path = os.path.join(repo, "translations", f"{code}.json")
-            self.catalogs[code] = json.load(open(path, encoding="utf-8"))
+            with open(path, encoding="utf-8") as f:
+                self.catalogs[code] = json.load(f)
         self.report_keys = [k for k in self.en if k.startswith("dialog.report.")]
 
     def test_dont_ask_again_key_exists(self):

--- a/tests.py
+++ b/tests.py
@@ -612,77 +612,116 @@ class TestVersionConsistency(unittest.TestCase):
 
 
 class TestReportURLs(unittest.TestCase):
-    """Verify test report URL generation is safe."""
+    """Verify test report URL generation is safe. These exercise the REAL
+    build_report_subject / build_report_body / build_report_url functions in
+    gui_dialogs (not a hand-rolled copy), so the shipped code path is guarded."""
+
+    def setUp(self):
+        import i18n
+        i18n.load_bundled_en()
+        try:
+            import gui_dialogs
+        except ImportError:
+            self.skipTest("gui_dialogs not importable in this environment")
+        self.gd = gui_dialogs
 
     def test_github_issue_url_is_valid(self):
         import urllib.parse
-        title = "Test Report: BTECH BF-F8HP Pro — SUCCESS"
-        body = "Radio: BTECH BF-F8HP Pro\nFirmware: test.kdhx\nResult: SUCCESS\n"
-        url = ("https://github.com/FlintWave/flintwave-kdh-flasher/issues/new?"
-               + urllib.parse.urlencode({"title": title, "body": body, "labels": "test-report"}))
+        subject = self.gd.build_report_subject("BTECH BF-F8HP Pro", True)
+        body = self.gd.build_report_body("BTECH BF-F8HP Pro", "test.kdhx", True, "")
+        url = self.gd.build_report_url(subject, body)
         self.assertTrue(url.startswith("https://github.com/FlintWave/flintwave-kdh-flasher/"))
         parsed = urllib.parse.urlparse(url)
         self.assertEqual(parsed.scheme, "https")
         self.assertEqual(parsed.hostname, "github.com")
 
     def test_github_url_includes_label(self):
-        import urllib.parse
-        title = "Test Report: BTECH BF-F8HP Pro — SUCCESS"
-        body = "Radio: BTECH BF-F8HP Pro\nResult: SUCCESS\n"
-        url = ("https://github.com/FlintWave/flintwave-kdh-flasher/issues/new?"
-               + urllib.parse.urlencode({"title": title, "body": body, "labels": "test-report"}))
+        subject = self.gd.build_report_subject("BTECH BF-F8HP Pro", True)
+        body = self.gd.build_report_body("BTECH BF-F8HP Pro", "test.kdhx", True, "")
+        url = self.gd.build_report_url(subject, body)
         self.assertIn("labels=test-report", url)
 
     def test_special_characters_escaped(self):
-        import urllib.parse
-        title = 'Test Report: Radio "Special" & <weird>'
-        body = "Line1\nLine2\n"
-        params = urllib.parse.urlencode({"title": title, "body": body})
-        self.assertNotIn("<", params)
-        self.assertNotIn(">", params)
-        self.assertNotIn('"', params)
+        subject = self.gd.build_report_subject('Radio "Special" & <weird>', False)
+        body = self.gd.build_report_body(
+            'Radio "Special" & <weird>', "fw<>.kdhx", False,
+            'boom & <error> "quoted"', "Line1\nLine2\n")
+        url = self.gd.build_report_url(subject, body)
+        self.assertNotIn("<", url)
+        self.assertNotIn(">", url)
+        self.assertNotIn('"', url)
+
+    def test_url_length_budget(self):
+        # Regression guard for the URL-length analysis in design.md: a
+        # worst-case log tail of all newlines (each encodes to "%0A", 3 bytes)
+        # at the documented truncation cap must still keep the fully encoded
+        # issues/new URL under the ~8000-char practical browser/GitHub ceiling.
+        log = "\n" * (self.gd.LOG_TRUNCATE_CHARS + 500)
+        subject = self.gd.build_report_subject("Some Radio Model", False)
+        body = self.gd.build_report_body(
+            "Some Radio Model", "firmware_v1.2.3.kdhx", False,
+            "some representative error message string", log)
+        url = self.gd.build_report_url(subject, body)
+        self.assertLess(len(url), 8000,
+                        f"encoded report URL is {len(url)} chars, over the 8000 budget")
 
 
 class TestReportGeneration(unittest.TestCase):
-    """Test that report body content is well-formed."""
+    """Test that report body content is well-formed. Exercises the REAL
+    build_report_body function in gui_dialogs."""
+
+    def setUp(self):
+        import i18n
+        i18n.load_bundled_en()
+        try:
+            import gui_dialogs
+        except ImportError:
+            self.skipTest("gui_dialogs not importable in this environment")
+        self.gd = gui_dialogs
 
     def test_success_report_body(self):
-        import platform
-        radio_name = "BTECH BF-F8HP Pro"
-        fw_file = "BTECH_V0.53_260116.kdhx"
-        report = (
-            f"Radio: {radio_name}\n"
-            f"Firmware: {fw_file}\n"
-            f"Result: SUCCESS\n"
-            f"OS: {platform.system()} {platform.release()}\n"
-            f"Python: {platform.python_version()}\n"
-        )
+        report = self.gd.build_report_body(
+            "BTECH BF-F8HP Pro",
+            "/home/user/downloads/BTECH_V0.53_260116.kdhx", True, "")
         self.assertIn("Radio: BTECH BF-F8HP Pro", report)
+        self.assertIn("Firmware: BTECH_V0.53_260116.kdhx", report)  # basename only
+        self.assertNotIn("/home/user/", report)  # no local path leaks
         self.assertIn("Result: SUCCESS", report)
         self.assertNotIn("Error:", report)
 
     def test_failure_report_body(self):
-        import platform
-        error_msg = "No response from radio"
-        report = (
-            f"Radio: RT-470\n"
-            f"Firmware: test.kdhx\n"
-            f"Result: FAILED\n"
-            f"OS: {platform.system()} {platform.release()}\n"
-            f"Python: {platform.python_version()}\n"
-            f"Error: {error_msg}\n"
-        )
+        report = self.gd.build_report_body(
+            "RT-470", "test.kdhx", False, "No response from radio")
         self.assertIn("Result: FAILED", report)
         self.assertIn("Error: No response from radio", report)
 
     def test_report_body_has_os_info(self):
         import platform
-        report = f"OS: {platform.system()} {platform.release()}\n"
+        report = self.gd.build_report_body("X", "f.kdhx", True, "")
         self.assertIn(platform.system(), report)
+        self.assertIn(platform.python_version(), report)
 
     def test_additional_notes_placeholder(self):
-        report_body = "Radio: Test\nResult: SUCCESS\n\nAdditional notes:\n"
-        self.assertTrue(report_body.endswith("Additional notes:\n"))
+        report = self.gd.build_report_body("Test", "f.kdhx", True, "")
+        self.assertIn("Additional notes:", report)
+
+    def test_missing_firmware_path_uses_unknown(self):
+        report = self.gd.build_report_body("X", "", True, "")
+        self.assertIn("Firmware: unknown", report)
+
+    def test_log_truncated_to_cap(self):
+        # A log longer than the cap keeps only its last LOG_TRUNCATE_CHARS chars.
+        cap = self.gd.LOG_TRUNCATE_CHARS
+        log = "A" * 100 + "B" * (cap + 500)
+        report = self.gd.build_report_body("X", "f.kdhx", True, "", log)
+        self.assertIn("--- Log ---", report)
+        self.assertNotIn("A" * 100, report)  # leading chars dropped
+        log_section = report.split("--- Log ---\n", 1)[1]
+        self.assertLessEqual(len(log_section), cap + 1)  # +1 for trailing newline
+
+    def test_short_log_not_truncated(self):
+        report = self.gd.build_report_body("X", "f.kdhx", True, "", "short log\n")
+        self.assertIn("short log", report)
 
 
 class TestThemePalettes(unittest.TestCase):
@@ -1022,6 +1061,49 @@ class TestFirmwareManifest(unittest.TestCase):
         self.assertIsNone(fm_mod.get_radio_firmware_info("nope", {}))
         self.assertIsNone(fm_mod.get_radio_firmware_info("nope", None))
 
+    def test_test_report_status_fresh_is_none(self):
+        fm_mod = self._use_temp_state()
+        self.assertIsNone(fm_mod.get_test_report_status("bf-f8hp-pro", "0.53"))
+
+    def test_mark_test_report_roundtrip(self):
+        fm_mod = self._use_temp_state()
+        fm_mod.mark_test_report("bf-f8hp-pro", "0.53", "submitted")
+        self.assertEqual(
+            fm_mod.get_test_report_status("bf-f8hp-pro", "0.53"), "submitted")
+
+    def test_mark_test_report_skipped_status(self):
+        fm_mod = self._use_temp_state()
+        fm_mod.mark_test_report("rt-470", "1.0", "skipped")
+        self.assertEqual(fm_mod.get_test_report_status("rt-470", "1.0"), "skipped")
+
+    def test_test_report_status_different_version_is_none(self):
+        fm_mod = self._use_temp_state()
+        fm_mod.mark_test_report("bf-f8hp-pro", "0.53", "submitted")
+        # A version bump on the same radio is a fresh combination.
+        self.assertIsNone(fm_mod.get_test_report_status("bf-f8hp-pro", "0.54"))
+
+    def test_test_report_falsy_version_uses_sentinel(self):
+        fm_mod = self._use_temp_state()
+        # An unparseable (falsy) version falls back to a sentinel; mark and get
+        # agree on it, so suppression degrades to keying on radio id alone.
+        fm_mod.mark_test_report("rt-950-pro", None, "submitted")
+        self.assertEqual(
+            fm_mod.get_test_report_status("rt-950-pro", None), "submitted")
+        self.assertEqual(
+            fm_mod.get_test_report_status("rt-950-pro", ""), "submitted")
+        self.assertEqual(
+            fm_mod.get_test_report_status(
+                "rt-950-pro", fm_mod.TEST_REPORT_UNKNOWN_VERSION),
+            "submitted")
+
+    def test_test_report_coexists_with_last_flashed(self):
+        fm_mod = self._use_temp_state()
+        fm_mod.record_flash("rt-470", "1.0", "hash1")
+        fm_mod.mark_test_report("rt-470", "1.0", "submitted")
+        # Both blocks live side by side in the same state file.
+        self.assertEqual(fm_mod.get_last_flashed("rt-470")["version"], "1.0")
+        self.assertEqual(fm_mod.get_test_report_status("rt-470", "1.0"), "submitted")
+
 
 class TestManifestSchema(unittest.TestCase):
     """Validate firmware_manifest.json structure."""
@@ -1337,6 +1419,153 @@ class TestRadioStringTranslations(unittest.TestCase):
         self.assertEqual(echoed, [],
                          f"{len(echoed)} translations identical to English "
                          f"source (model echo): {echoed[:5]}")
+
+
+class TestDialogReportTranslations(unittest.TestCase):
+    """Every `dialog.report.*` key in the English catalog must be present in
+    each shipped catalog, and prose keys must not echo the English source.
+
+    Guards the new "don't ask again" affordance the same way
+    TestRadioStringTranslations guards per-radio strings. A small allowlist
+    covers keys whose value is a loanword/abbreviation/proper-noun legitimately
+    identical across locales ("Firmware:", "OS:", "Python:", "Radio:",
+    "Error:", "--- Log ---")."""
+
+    REQUIRED_LANGS = ["zh-CN", "fr", "de", "it", "es", "ar", "ru"]
+    # Keys whose English value may legitimately appear verbatim in a catalog.
+    ECHO_ALLOWED = {
+        "dialog.report.body_radio",
+        "dialog.report.body_firmware",
+        "dialog.report.body_os",
+        "dialog.report.body_python",
+        "dialog.report.body_error",
+        "dialog.report.body_log_header",
+    }
+
+    def setUp(self):
+        repo = os.path.dirname(__file__)
+        self.en = json.load(
+            open(os.path.join(repo, "translations", "en.json"), encoding="utf-8"))
+        self.catalogs = {}
+        for code in self.REQUIRED_LANGS:
+            path = os.path.join(repo, "translations", f"{code}.json")
+            self.catalogs[code] = json.load(open(path, encoding="utf-8"))
+        self.report_keys = [k for k in self.en if k.startswith("dialog.report.")]
+
+    def test_dont_ask_again_key_exists(self):
+        self.assertIn("dialog.report.dont_ask_again", self.en)
+
+    def test_all_report_keys_present_in_every_lang(self):
+        missing = []
+        for key in self.report_keys:
+            for code, cat in self.catalogs.items():
+                if key not in cat:
+                    missing.append(f"{code}: {key}")
+        self.assertEqual(missing, [],
+                         f"{len(missing)} missing dialog.report translations: "
+                         f"{missing[:5]}")
+
+    def test_prose_report_keys_actually_translated(self):
+        echoed = []
+        for key in self.report_keys:
+            if key in self.ECHO_ALLOWED:
+                continue
+            src = self.en[key].strip()
+            for code, cat in self.catalogs.items():
+                if cat.get(key, "").strip() == src:
+                    echoed.append(f"{code}: {key}")
+        self.assertEqual(echoed, [],
+                         f"{len(echoed)} dialog.report translations identical to "
+                         f"English source (model echo): {echoed[:5]}")
+
+
+class TestOfferTestReportSuppression(unittest.TestCase):
+    """FlasherFrame._offer_test_report must not show the dialog once a report
+    was submitted or explicitly skipped for a given radio+version, and must
+    persist the dialog's outcome otherwise. Bound onto a lightweight stub so it
+    runs headlessly (no wx.Frame / display), the pattern the variant-gating
+    tests use. The report dialog itself is monkeypatched out."""
+
+    def setUp(self):
+        import importlib
+        try:
+            self.gm = importlib.import_module("gui_main")
+        except ImportError:
+            self.skipTest("gui_main not importable in this environment")
+        import firmware_manifest as fm_mod
+        self.fm = fm_mod
+        self._orig_state_file = fm_mod.STATE_FILE
+        self._orig_state_dir = fm_mod.STATE_DIR
+        self._tmpdir = tempfile.mkdtemp()
+        fm_mod.STATE_FILE = os.path.join(self._tmpdir, "state.json")
+        fm_mod.STATE_DIR = self._tmpdir
+        self._orig_dialog = self.gm.show_test_report_dialog
+
+    def tearDown(self):
+        self.fm.STATE_FILE = self._orig_state_file
+        self.fm.STATE_DIR = self._orig_state_dir
+        self.gm.show_test_report_dialog = self._orig_dialog
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _stub(self, dialog_return):
+        calls = []
+
+        def fake_dialog(*args, **kwargs):
+            calls.append(args)
+            return dialog_return
+
+        self.gm.show_test_report_dialog = fake_dialog
+        stub = types.SimpleNamespace()
+        stub.log = types.SimpleNamespace(GetValue=lambda: "log text")
+        stub._offer_firmware_cleanup = lambda path: None
+        stub._offer_test_report = \
+            self.gm.FlasherFrame._offer_test_report.__get__(stub)
+        return stub, calls
+
+    def test_suppressed_after_submitted(self):
+        self.fm.mark_test_report("radio-x", "1.0", "submitted")
+        stub, calls = self._stub(None)
+        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
+                                radio_id="radio-x", file_version="1.0")
+        self.assertEqual(calls, [], "dialog must not be shown when suppressed")
+
+    def test_suppressed_after_skipped(self):
+        self.fm.mark_test_report("radio-x", "1.0", "skipped")
+        stub, calls = self._stub(None)
+        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", False, "boom",
+                                radio_id="radio-x", file_version="1.0")
+        self.assertEqual(calls, [])
+
+    def test_shown_when_not_recorded_and_plain_skip_does_not_persist(self):
+        stub, calls = self._stub(None)  # dialog returns None => plain Skip
+        stub._offer_test_report("Radio Y", "/tmp/fw.kdhx", True, "",
+                                radio_id="radio-y", file_version="1.0")
+        self.assertEqual(len(calls), 1)
+        # Plain Skip persists nothing, so a future flash still prompts.
+        self.assertIsNone(self.fm.get_test_report_status("radio-y", "1.0"))
+
+    def test_submit_outcome_persisted(self):
+        stub, calls = self._stub("submitted")
+        stub._offer_test_report("Radio Z", "/tmp/fw.kdhx", True, "",
+                                radio_id="radio-z", file_version="2.0")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            self.fm.get_test_report_status("radio-z", "2.0"), "submitted")
+
+    def test_skip_with_checkbox_persisted(self):
+        stub, calls = self._stub("skipped")
+        stub._offer_test_report("Radio W", "/tmp/fw.kdhx", False, "boom",
+                                radio_id="radio-w", file_version="3.0")
+        self.assertEqual(
+            self.fm.get_test_report_status("radio-w", "3.0"), "skipped")
+
+    def test_new_version_prompts_again(self):
+        self.fm.mark_test_report("radio-x", "1.0", "submitted")
+        stub, calls = self._stub(None)
+        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
+                                radio_id="radio-x", file_version="2.0")
+        self.assertEqual(len(calls), 1, "a new firmware version must prompt again")
 
 
 class TestVariantGroupTranslations(unittest.TestCase):

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -70,6 +70,7 @@
   "dialog.report.success": "اكتملت البرمجة بنجاح!\nهل ترغب في إرسال تقرير اختبار؟",
   "dialog.report.failure": "فشلت البرمجة.\nهل ترغب في إرسال تقرير لمساعدتنا في التصحيح؟",
   "dialog.report.email_hint": "يمكنك أيضًا إرسال التقارير عبر البريد إلى flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "لا تسأل مرة أخرى عن هذا الجهاز وإصدار البرنامج الثابت",
   "dialog.report.subject": "تقرير اختبار: {radio} — {status}",
   "dialog.report.result_success": "نجاح",
   "dialog.report.result_failure": "فشل",

--- a/translations/de.json
+++ b/translations/de.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "Flashvorgang erfolgreich abgeschlossen!\nMöchten Sie einen Testbericht einreichen?",
   "dialog.report.failure": "Flashvorgang fehlgeschlagen.\nMöchten Sie einen Bericht einreichen, der uns beim Debugging hilft?",
   "dialog.report.email_hint": "Sie können Berichte auch an flintwave@tuta.com senden",
+  "dialog.report.dont_ask_again": "Für dieses Funkgerät und diese Firmware-Version nicht mehr fragen",
   "dialog.report.subject": "Testbericht: {radio} — {status}",
   "dialog.report.result_success": "ERFOLG",
   "dialog.report.result_failure": "FEHLER",

--- a/translations/en.json
+++ b/translations/en.json
@@ -86,6 +86,7 @@
   "dialog.report.success": "Flash completed successfully!\nWould you like to submit a test report?",
   "dialog.report.failure": "Flash failed.\nWould you like to submit a report to help us debug?",
   "dialog.report.email_hint": "You can also email reports to flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "Don't ask again for this radio and firmware version",
   "dialog.report.subject": "Test Report: {radio} — {status}",
   "dialog.report.result_success": "SUCCESS",
   "dialog.report.result_failure": "FAILED",

--- a/translations/es.json
+++ b/translations/es.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "¡Flasheo completado con éxito!\n¿Quieres enviar un informe de prueba?",
   "dialog.report.failure": "El flasheo falló.\n¿Quieres enviar un informe para ayudarnos a depurar?",
   "dialog.report.email_hint": "También puedes enviar informes por correo a flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "No volver a preguntar por esta radio y versión de firmware",
   "dialog.report.subject": "Informe de prueba: {radio} — {status}",
   "dialog.report.result_success": "ÉXITO",
   "dialog.report.result_failure": "FALLIDO",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "Le flashage s'est terminé avec succès !\nSouhaitez-vous soumettre un rapport de test ?",
   "dialog.report.failure": "Le flashage a échoué.\nSouhaitez-vous soumettre un rapport pour nous aider à déboguer ?",
   "dialog.report.email_hint": "Vous pouvez également envoyer les rapports par e-mail à flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "Ne plus demander pour cette radio et cette version de micrologiciel",
   "dialog.report.subject": "Rapport de test : {radio} — {status}",
   "dialog.report.result_success": "SUCCÈS",
   "dialog.report.result_failure": "ÉCHEC",

--- a/translations/it.json
+++ b/translations/it.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "Flash completato con successo!\nVuoi inviare un rapporto di test?",
   "dialog.report.failure": "Flash fallito.\nVuoi inviare un rapporto per aiutarci a fare debug?",
   "dialog.report.email_hint": "Puoi anche inviare i rapporti via email a flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "Non chiedere più per questa radio e versione del firmware",
   "dialog.report.subject": "Rapporto di test: {radio} — {status}",
   "dialog.report.result_success": "SUCCESSO",
   "dialog.report.result_failure": "FALLITO",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "Прошивка успешно завершена!\nХотите отправить отчёт о тестировании?",
   "dialog.report.failure": "Прошивка не удалась.\nХотите отправить отчёт, чтобы помочь нам в отладке?",
   "dialog.report.email_hint": "Вы также можете отправлять отчёты по адресу flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "Больше не спрашивать для этой радиостанции и версии прошивки",
   "dialog.report.subject": "Отчёт о тестировании: {radio} — {status}",
   "dialog.report.result_success": "УСПЕХ",
   "dialog.report.result_failure": "СБОЙ",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -69,6 +69,7 @@
   "dialog.report.success": "刷写已成功完成!\n是否提交测试报告?",
   "dialog.report.failure": "刷写失败。\n是否提交报告以帮助我们调试?",
   "dialog.report.email_hint": "您也可以将报告发送至 flintwave@tuta.com",
+  "dialog.report.dont_ask_again": "对此电台和固件版本不再询问",
   "dialog.report.subject": "测试报告:{radio} — {status}",
   "dialog.report.result_success": "成功",
   "dialog.report.result_failure": "失败",


### PR DESCRIPTION
## Summary

Implements [`openspec/changes/one-click-test-reports`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/one-click-test-reports/proposal.md). The post-flash report dialog (which produced #20) already worked — this fixes what didn't:

- **No more nagging**: a "don't ask again for this radio + firmware version" checkbox suppresses per (radio id, version) via a new `test_reports` block in the state file (atomic writes, firmware_manifest.py-style helpers). Plain Skip does not suppress; a new firmware version re-opens the offer. Wired in both flash completion paths (KDH + BTF), success and failure.
- **Testable builders**: `build_report_subject` / `build_report_body` / `build_report_url` extracted wx-free from the dialog; `TestReportURLs`/`TestReportGeneration` now exercise the real functions instead of re-deriving the logic, plus a URL-length budget regression test (2000-char log truncation vs the ~8k practical URL ceiling).
- **i18n**: new `dialog.report.dont_ask_again` key translated in all 7 catalogs; a new translation test enforces presence for all `dialog.report.*` keys and non-echo for the prose keys (allowlisting the six legitimate loanword lines like `Firmware:` / `OS:`).
- Maintainer convention (`test-report` label + `Radio:` body line → `tested` flag flips) documented per the design doc.

## Testing

Suite: 188 → **207**, all green; smoke launch clean. Implemented by an Opus agent from the OpenSpec scaffold; reviewed and changelog added by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD