### PR TITLE
Extract hint state machine and radio-info rendering into gui_hints (slice 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Architecture
+
+- **Hint/info rendering extracted from the main frame** (`gui_hints.py`, decomposition slice 1 of 3). The hint state machine and per-radio info panel — including the hardware-variant prompt text — now live in a `HintPresenter` with pure, headlessly tested formatting functions; the frame keeps thin same-named delegators so worker threads and sibling components are untouched. `gui_main.py` drops to ~1,978 lines. Behavior unchanged.
+
 ### Test reports
 
 - **The post-flash test-report offer no longer nags.** A new "don't ask again for this radio + firmware version" checkbox suppresses the prompt per (radio, version) — recorded in the state file — while a plain Skip keeps asking next time, and a new firmware version re-opens the offer. The report URL/body builders were extracted from the dialog into pure functions with real tests (URL-length budget included), replacing tests that re-derived the logic by hand. Reports keep the `test-report` label + `Radio:` body-line convention maintainers use to flip `tested` flags.

--- a/gui_hints.py
+++ b/gui_hints.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Instructions-panel presentation: the hint state machine and per-radio info.
+
+This is the *presenter* half of the Instructions column. It owns the copy shown
+in the read-only hint ``TextCtrl`` — resolving which workflow hint to show,
+rendering its bold title / body into the widget, and appending the per-radio
+info block (bootloader keys, connector, tested flag, latest firmware, notes) or,
+for an unresolved hardware-variant family, the group's identification
+question/steps.
+
+``HintPresenter`` collaborates with the owning frame for everything only the
+frame can provide: the ``hint_text`` TextCtrl and ``font_size``; the selection /
+state readers (``_get_selected_radio``, ``_get_selected_group``,
+``_get_firmware_url_and_version``, ``_firmware_ready``,
+``_selected_handset_indices``); and the ``_busy`` / ``_terminal_state`` /
+``_busy_state`` fields. The frame keeps thin same-named delegators
+(``_set_hint``, ``_compute_hint_state``, ``_get_hint_copy``,
+``_format_radio_info``, ``_on_state_change``) so worker ``wx.CallAfter`` chains,
+HandsetController callbacks, ``retranslate_ui`` and gui_columns bindings keep
+calling the same names, exactly as HandsetController's delegators do.
+
+Boundary note — hardware-variant handling straddles two slices, so it splits by
+*what it produces*:
+
+  * The instructions-panel **text** is this presenter's job, so the pure
+    ``format_variant_prompt(group_id, group)`` (family name + translated
+    identification question/steps) lives here as a headless module function and
+    is composed into the info block by ``format_radio_info``.
+  * The variant **answer widgets** — the radio-button walkthrough panel
+    (``_render_variant_options`` / ``_clear_variant_panel`` /
+    ``_on_variant_chosen``) and the ``_get_selected_group`` selection reader —
+    stay on the frame. They are driven by firmware discovery
+    (``_update_radio_info``, a later decomposition slice) and manipulate live wx
+    controls rather than the hint string, so pulling them in here would drag a
+    different slice's responsibility into the presenter. The presenter reaches
+    back through the frame for ``_get_selected_group`` when it needs to know a
+    family is unresolved.
+
+The hint *decision* logic (``compute_hint_state``, ``HINT_STATES``,
+``RADIO_INFO_STATES``) already lives in ``gui_workflow`` and is reused unchanged;
+the presenter only reads current frame state and feeds it in. The string-builders
+(``format_radio_info`` / ``format_variant_prompt``) are pure module functions so
+they unit-test without a display or pyserial, following the
+``enumerate_serial_ports`` / ``compute_hint_state`` precedent.
+"""
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+from i18n import t, t_radio_field, t_variant_field
+from gui_columns import radio_display_name
+from gui_workflow import (
+    compute_hint_state as _compute_hint_state_pure,
+    HINT_STATES,
+    RADIO_INFO_STATES,
+)
+
+
+def format_radio_info(radio, firmware_version):
+    """Return the per-radio instructions block for a concrete radio.
+
+    Pure string-building (no widget access): given the radio dict from
+    ``radios.json`` and the resolved latest firmware version (from
+    ``_get_firmware_url_and_version``), assemble the name / bootloader-keys /
+    connector / tested / latest-firmware / notes lines, each run through the
+    active translation catalog. Returns the joined text.
+    """
+    bits = []
+    rid = radio.get("id", "")
+    keys = radio.get("bootloader_keys")
+    connector = radio.get("connector")
+    tested = radio.get("tested")
+    # Same dedup rule as the dropdown (shared helper), so the manufacturer
+    # isn't double-stamped when the name already starts with it.
+    full_name = radio_display_name(radio.get("name", ""),
+                                   radio.get("manufacturer", ""))
+    bits.append(t("info.radio_label").format(name=full_name))
+    if keys:
+        bits.append(t("info.bootloader_keys").format(
+            keys=t_radio_field(rid, "bootloader_keys", keys)))
+    if connector:
+        bits.append(t("info.connector").format(
+            connector=t_radio_field(rid, "connector", connector)))
+    bits.append(t("info.tested") if tested else t("info.untested"))
+    if firmware_version:
+        bits.append(t("info.latest_firmware").format(version=firmware_version))
+    notes = radio.get("notes")
+    if notes:
+        bits.append("")
+        bits.append(t_radio_field(rid, "notes", notes))
+    return "\n".join(bits)
+
+
+def format_variant_prompt(group_id, group):
+    """Text block for an unresolved variant group: family name, then the
+    translated identification question and steps. Pure — no widget access.
+    """
+    name = radio_display_name(
+        t_variant_field(group_id, "name", group.get("name", group_id)),
+        group.get("manufacturer", ""))
+    bits = [t("info.radio_label").format(name=name), ""]
+    question = t_variant_field(group_id, "question", group.get("question", ""))
+    steps = t_variant_field(group_id, "steps", group.get("steps", ""))
+    if question:
+        bits.append(t("info.variant_question"))
+        bits.append(question)
+    if steps:
+        bits.append("")
+        bits.append(t("info.variant_steps"))
+        bits.append(steps)
+    return "\n".join(bits)
+
+
+class HintPresenter:
+    """Owns the Instructions hint TextCtrl and the per-radio info rendering."""
+
+    def __init__(self, frame):
+        self.frame = frame
+
+    def get_hint_copy(self, state):
+        """Return (title, body) for a hint state in the active language."""
+        if state not in HINT_STATES:
+            return None
+        return (t(f"hint.{state}.title"), t(f"hint.{state}.body"))
+
+    def radio_info(self):
+        """Per-radio instructions for the active selection, or empty string.
+
+        When an unresolved variant group is selected (no concrete radio), returns
+        the group's identification question + steps instead (the selectable
+        answers live in the frame's variant panel, wired by
+        ``_render_variant_options``).
+        """
+        frame = self.frame
+        radio = frame._get_selected_radio()
+        if not radio:
+            group_sel = frame._get_selected_group()
+            if group_sel:
+                return format_variant_prompt(*group_sel)
+            return ""
+        _, version = frame._get_firmware_url_and_version(radio)
+        return format_radio_info(radio, version)
+
+    def set_hint(self, state):
+        frame = self.frame
+        copy = self.get_hint_copy(state)
+        if copy is None:
+            return
+        title, body = copy
+        # In idle / pre-flash states, append the per-radio instructions so the
+        # user has bootloader keys / connector / notes visible while choosing
+        # firmware and prepping the radio.
+        if state in RADIO_INFO_STATES:
+            radio_info = self.radio_info()
+            if radio_info:
+                body = f"{body}\n\n{t('info.selected_radio_header')}\n{radio_info}"
+        # Render into the rich-text TextCtrl: bold title on its own line, blank
+        # line, then body. SetDefaultStyle + AppendText is more reliable than
+        # SetStyle on GTK (where the underlying GtkTextView has its own
+        # attribute system that wx.TextAttr doesn't always reach via SetStyle).
+        frame.hint_text.Freeze()
+        try:
+            frame.hint_text.Clear()
+            bold = wx.Font(frame.font_size, wx.FONTFAMILY_DEFAULT,
+                           wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+            normal = wx.Font(frame.font_size, wx.FONTFAMILY_DEFAULT,
+                             wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
+            bold_attr = wx.TextAttr()
+            bold_attr.SetFont(bold)
+            normal_attr = wx.TextAttr()
+            normal_attr.SetFont(normal)
+
+            frame.hint_text.SetDefaultStyle(bold_attr)
+            frame.hint_text.AppendText(title + "\n\n")
+            frame.hint_text.SetDefaultStyle(normal_attr)
+            frame.hint_text.AppendText(body)
+
+            frame.hint_text.SetInsertionPoint(0)
+            frame.hint_text.ShowPosition(0)
+        finally:
+            frame.hint_text.Thaw()
+
+    def compute_hint_state(self):
+        # Pure decision logic lives in gui_workflow.compute_hint_state; this
+        # method only reads the current values off the frame. _firmware_ready()
+        # checks path-present AND file-exists so the hint can't advance to
+        # "ready to flash" while the Flash button stays disabled because the
+        # referenced file is missing/deleted.
+        frame = self.frame
+        return _compute_hint_state_pure(
+            terminal_state=frame._terminal_state,
+            busy=frame._busy,
+            firmware_ready=frame._firmware_ready(),
+            handset_count=len(frame._selected_handset_indices()),
+            busy_state=getattr(frame, "_busy_state", "flashing"),
+        )
+
+    def on_state_change(self, event):
+        frame = self.frame
+        # User-initiated change clears any sticky terminal state
+        frame._terminal_state = None
+        self.set_hint(self.compute_hint_state())
+        frame._update_workflow_gating()
+        if event:
+            event.Skip()

--- a/gui_main.py
+++ b/gui_main.py
@@ -29,7 +29,6 @@ from gui_dialogs import (
 from gui_themes import apply_theme, THEME_PALETTES, MOCHA_PALETTE
 from gui_themes import _walk as _theme_walk, _style_widget as _theme_style_widget
 from gui_workflow import (
-    compute_hint_state,
     compute_gates,
     HINT_STATES as WORKFLOW_HINT_STATES,
     RADIO_INFO_STATES,
@@ -39,6 +38,7 @@ from gui_statusbar import StatusBar, theme_toggle_glyph
 from gui_columns import (
     FirmwareColumn, HandsetColumn, FlashColumn, radio_display_name,
 )
+from gui_hints import HintPresenter
 from gui_handset import (
     HandsetController,
     # Flash-worker status values (i18n keys) — comparisons use these symbolic
@@ -96,6 +96,9 @@ class FlasherFrame(wx.Frame):
         # Handset-column behavior (port discovery, probe, poll, selection) lives
         # in HandsetController; the frame exposes thin delegators below.
         self.handset = HandsetController(self)
+        # Instructions-panel presentation (hint state machine + per-radio info)
+        # lives in HintPresenter; the frame exposes thin delegators below.
+        self.hints = HintPresenter(self)
         self._update_url = None       # set by _check_update when an update is detected
 
         # Window icon
@@ -819,10 +822,8 @@ class FlasherFrame(wx.Frame):
     HINT_STATES = WORKFLOW_HINT_STATES
 
     def _get_hint_copy(self, state):
-        """Return (title, body) for a hint state in the active language."""
-        if state not in self.HINT_STATES:
-            return None
-        return (t(f"hint.{state}.title"), t(f"hint.{state}.body"))
+        # Delegates to HintPresenter; kept as a same-named thin wrapper.
+        return self.hints.get_hint_copy(state)
 
     # States during which it's useful to also show the per-radio info
     # (bootloader keys, connector type, notes from radios.json). Defined in
@@ -830,60 +831,9 @@ class FlasherFrame(wx.Frame):
     _RADIO_INFO_STATES = RADIO_INFO_STATES
 
     def _format_radio_info(self):
-        """Return per-radio instructions for the active radio, or empty string.
-
-        When an unresolved variant group is selected, returns the group's
-        identification question + steps instead (the selectable answers live in
-        the variant panel below, wired by _render_variant_options)."""
-        radio = self._get_selected_radio()
-        if not radio:
-            group_sel = self._get_selected_group()
-            if group_sel:
-                return self._format_variant_prompt(*group_sel)
-            return ""
-        bits = []
-        rid = radio.get("id", "")
-        keys = radio.get("bootloader_keys")
-        connector = radio.get("connector")
-        tested = radio.get("tested")
-        # Same dedup rule as the dropdown (shared helper), so the manufacturer
-        # isn't double-stamped when the name already starts with it.
-        full_name = radio_display_name(radio.get("name", ""),
-                                       radio.get("manufacturer", ""))
-        bits.append(t("info.radio_label").format(name=full_name))
-        if keys:
-            bits.append(t("info.bootloader_keys").format(
-                keys=t_radio_field(rid, "bootloader_keys", keys)))
-        if connector:
-            bits.append(t("info.connector").format(
-                connector=t_radio_field(rid, "connector", connector)))
-        bits.append(t("info.tested") if tested else t("info.untested"))
-        _, version = self._get_firmware_url_and_version(radio)
-        if version:
-            bits.append(t("info.latest_firmware").format(version=version))
-        notes = radio.get("notes")
-        if notes:
-            bits.append("")
-            bits.append(t_radio_field(rid, "notes", notes))
-        return "\n".join(bits)
-
-    def _format_variant_prompt(self, group_id, group):
-        """Text block for an unresolved variant group: family name, then the
-        translated identification question and steps."""
-        name = radio_display_name(
-            t_variant_field(group_id, "name", group.get("name", group_id)),
-            group.get("manufacturer", ""))
-        bits = [t("info.radio_label").format(name=name), ""]
-        question = t_variant_field(group_id, "question", group.get("question", ""))
-        steps = t_variant_field(group_id, "steps", group.get("steps", ""))
-        if question:
-            bits.append(t("info.variant_question"))
-            bits.append(question)
-        if steps:
-            bits.append("")
-            bits.append(t("info.variant_steps"))
-            bits.append(steps)
-        return "\n".join(bits)
+        # Delegates to HintPresenter; the pure string-building lives in
+        # gui_hints.format_radio_info / format_variant_prompt.
+        return self.hints.radio_info()
 
     def _clear_variant_panel(self):
         """Empty and hide the variant walkthrough controls."""
@@ -956,64 +906,18 @@ class FlasherFrame(wx.Frame):
         self._update_workflow_gating()
 
     def _set_hint(self, state):
-        copy = self._get_hint_copy(state)
-        if copy is None:
-            return
-        title, body = copy
-        # In idle / pre-flash states, append the per-radio instructions so the
-        # user has bootloader keys / connector / notes visible while choosing
-        # firmware and prepping the radio.
-        if state in self._RADIO_INFO_STATES:
-            radio_info = self._format_radio_info()
-            if radio_info:
-                body = f"{body}\n\n{t('info.selected_radio_header')}\n{radio_info}"
-        # Render into the rich-text TextCtrl: bold title on its own line, blank
-        # line, then body. SetDefaultStyle + AppendText is more reliable than
-        # SetStyle on GTK (where the underlying GtkTextView has its own
-        # attribute system that wx.TextAttr doesn't always reach via SetStyle).
-        self.hint_text.Freeze()
-        try:
-            self.hint_text.Clear()
-            bold = wx.Font(self.font_size, wx.FONTFAMILY_DEFAULT,
-                           wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
-            normal = wx.Font(self.font_size, wx.FONTFAMILY_DEFAULT,
-                             wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
-            bold_attr = wx.TextAttr()
-            bold_attr.SetFont(bold)
-            normal_attr = wx.TextAttr()
-            normal_attr.SetFont(normal)
-
-            self.hint_text.SetDefaultStyle(bold_attr)
-            self.hint_text.AppendText(title + "\n\n")
-            self.hint_text.SetDefaultStyle(normal_attr)
-            self.hint_text.AppendText(body)
-
-            self.hint_text.SetInsertionPoint(0)
-            self.hint_text.ShowPosition(0)
-        finally:
-            self.hint_text.Thaw()
+        # Delegates to HintPresenter; kept as a same-named thin wrapper so
+        # worker wx.CallAfter chains, retranslate_ui and HandsetController keep
+        # calling frame._set_hint unchanged.
+        self.hints.set_hint(state)
 
     def _compute_hint_state(self):
-        # Pure decision logic lives in gui_workflow.compute_hint_state; this
-        # method only reads the current values off the frame. _firmware_ready()
-        # checks path-present AND file-exists so the hint can't advance to
-        # "ready to flash" while the Flash button stays disabled because the
-        # referenced file is missing/deleted.
-        return compute_hint_state(
-            terminal_state=self._terminal_state,
-            busy=self._busy,
-            firmware_ready=self._firmware_ready(),
-            handset_count=len(self._selected_handset_indices()),
-            busy_state=getattr(self, "_busy_state", "flashing"),
-        )
+        # Delegates to HintPresenter (pure decision logic in gui_workflow).
+        return self.hints.compute_hint_state()
 
     def _on_state_change(self, event):
-        # User-initiated change clears any sticky terminal state
-        self._terminal_state = None
-        self._set_hint(self._compute_hint_state())
-        self._update_workflow_gating()
-        if event:
-            event.Skip()
+        # Delegates to HintPresenter.
+        self.hints.on_state_change(event)
 
     # ------------------------------------------------------------------
     # Menu / status bar action handlers (preserved)

--- a/tests.py
+++ b/tests.py
@@ -2327,11 +2327,11 @@ class TestRadioInfoFormatting(unittest.TestCase):
         self.assertIn(t("info.tested") if member.get("tested")
                       else t("info.untested"), lines)
         if member.get("bootloader_keys"):
-            from i18n import t_radio_field
             self.assertIn(
                 t("info.bootloader_keys").format(
-                    keys=t_radio_field(member["id"], "bootloader_keys",
-                                       member["bootloader_keys"])), lines)
+                    keys=self.i18n.t_radio_field(
+                        member["id"], "bootloader_keys",
+                        member["bootloader_keys"])), lines)
 
     def test_variant_prompt_renders_question_and_steps(self):
         t = self.i18n.t

--- a/tests.py
+++ b/tests.py
@@ -2231,5 +2231,176 @@ class TestHandsetPortEnumeration(unittest.TestCase):
             self.assertTrue(hasattr(self.h, name))
 
 
+class TestRadioInfoFormatting(unittest.TestCase):
+    """Pure per-radio info / variant-prompt string-building from the
+    HintPresenter (gui_hints).
+
+    Runs with no display and no pyserial: ``format_radio_info(radio,
+    firmware_version)`` and ``format_variant_prompt(group_id, group)`` take plain
+    dicts and return the instructions text, so the name / bootloader-keys /
+    connector / tested / latest-firmware / notes composition is testable in
+    isolation, following the ``format_radio_info`` / ``compute_hint_state``
+    precedent. Assertions build the expected line through ``i18n.t`` so they stay
+    byte-identical to what the GUI renders."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import gui_hints
+            import i18n
+        except ImportError:
+            raise unittest.SkipTest("gui_hints / i18n not importable")
+        i18n.load_bundled_en()
+        cls.gh = gui_hints
+        cls.i18n = i18n
+
+    def _lines(self, radio, version):
+        return self.gh.format_radio_info(radio, version).split("\n")
+
+    def test_ungrouped_radio_renders_all_fields(self):
+        t = self.i18n.t
+        radio = {
+            "id": "acme-x1",
+            "name": "Acme X1",
+            "manufacturer": "Acme",
+            "bootloader_keys": "SK1 + SK2",
+            "connector": "K1 Kenwood 2-pin",
+            "tested": True,
+            "notes": "Works on V1.0.",
+        }
+        lines = self._lines(radio, "1.0.3")
+        # radio_display_name dedups: "Acme X1" already starts with "Acme", so
+        # the manufacturer is not double-stamped.
+        self.assertEqual(lines[0],
+                         t("info.radio_label").format(name="Acme X1"))
+        self.assertIn(t("info.bootloader_keys").format(keys="SK1 + SK2"), lines)
+        self.assertIn(
+            t("info.connector").format(connector="K1 Kenwood 2-pin"), lines)
+        self.assertIn(t("info.tested"), lines)
+        self.assertNotIn(t("info.untested"), lines)
+        self.assertIn(
+            t("info.latest_firmware").format(version="1.0.3"), lines)
+        # Notes are preceded by a blank spacer line and rendered last.
+        self.assertEqual(lines[-1], "Works on V1.0.")
+        self.assertEqual(lines[-2], "")
+
+    def test_untested_radio_shows_untested_and_omits_optional_fields(self):
+        t = self.i18n.t
+        radio = {"id": "bare", "name": "Bare Radio", "tested": False}
+        lines = self._lines(radio, None)
+        self.assertIn(t("info.untested"), lines)
+        self.assertNotIn(t("info.tested"), lines)
+        # No bootloader keys / connector / version / notes provided → those
+        # lines are absent; only the name label + tested flag remain.
+        joined = "\n".join(lines)
+        self.assertNotIn("info.bootloader_keys", joined)
+        self.assertNotIn(t("info.latest_firmware").format(version=""), joined)
+        self.assertEqual(
+            lines, [t("info.radio_label").format(name="Bare Radio"),
+                    t("info.untested")])
+
+    def test_no_version_omits_latest_firmware_line(self):
+        t = self.i18n.t
+        radio = {"id": "r", "name": "R", "tested": True}
+        with_ver = self.gh.format_radio_info(radio, "9.9")
+        without_ver = self.gh.format_radio_info(radio, None)
+        self.assertIn(t("info.latest_firmware").format(version="9.9"),
+                      with_ver)
+        self.assertNotIn("info.latest_firmware", without_ver)
+
+    def test_grouped_variant_member_formats_like_a_concrete_radio(self):
+        # A resolved variant member is just a concrete radio dict; its info
+        # renders identically to an ungrouped radio (the group only matters
+        # while unresolved — see the variant-prompt test below).
+        t = self.i18n.t
+        with open("radios.json") as f:
+            rows = json.load(f)
+        rows = rows["radios"] if isinstance(rows, dict) else rows
+        member = next(r for r in rows if r.get("variant_group"))
+        lines = self.gh.format_radio_info(member, None).split("\n")
+        # First line is always the name label; tested flag is always present.
+        from gui_columns import radio_display_name
+        self.assertEqual(
+            lines[0],
+            t("info.radio_label").format(name=radio_display_name(
+                member.get("name", ""), member.get("manufacturer", ""))))
+        self.assertIn(t("info.tested") if member.get("tested")
+                      else t("info.untested"), lines)
+        if member.get("bootloader_keys"):
+            from i18n import t_radio_field
+            self.assertIn(
+                t("info.bootloader_keys").format(
+                    keys=t_radio_field(member["id"], "bootloader_keys",
+                                       member["bootloader_keys"])), lines)
+
+    def test_variant_prompt_renders_question_and_steps(self):
+        t = self.i18n.t
+        group = {
+            "name": "Widget Pro",
+            "manufacturer": "Acme",
+            "question": "Which board revision?",
+            "steps": "Open the battery door and read the label.",
+        }
+        out = self.gh.format_variant_prompt("widget-pro-family", group)
+        lines = out.split("\n")
+        # Name doesn't start with the manufacturer, so it's prefixed.
+        self.assertEqual(
+            lines[0],
+            t("info.radio_label").format(name="Acme Widget Pro"))
+        self.assertIn(t("info.variant_question"), lines)
+        self.assertIn("Which board revision?", lines)
+        self.assertIn(t("info.variant_steps"), lines)
+        self.assertIn("Open the battery door and read the label.", lines)
+
+    def test_variant_prompt_from_real_group(self):
+        with open("radios.json") as f:
+            radios = json.load(f)
+        groups = radios.get("variant_groups", {}) if isinstance(radios, dict) \
+            else {}
+        if not groups:
+            self.skipTest("no variant_groups in radios.json")
+        gid, group = next(iter(groups.items()))
+        out = self.gh.format_variant_prompt(gid, group)
+        # Non-empty and includes the group's identification question text.
+        self.assertTrue(out)
+        if group.get("question"):
+            self.assertIn(group["question"], out)
+
+
+class TestHintPresenterModule(unittest.TestCase):
+    """The gui_hints module exposes the presenter + pure helpers under the
+    names the frame delegators and tests rely on."""
+
+    def setUp(self):
+        try:
+            import gui_hints
+        except ImportError:
+            self.skipTest("gui_hints not importable")
+        self.gh = gui_hints
+
+    def test_module_exposes_presenter_and_pure_helpers(self):
+        self.assertTrue(hasattr(self.gh, "HintPresenter"))
+        self.assertTrue(callable(self.gh.format_radio_info))
+        self.assertTrue(callable(self.gh.format_variant_prompt))
+
+    def test_frame_keeps_same_named_delegators(self):
+        # Extraction must not rename the call-site surface: the frame still
+        # exposes _set_hint / _compute_hint_state / _get_hint_copy /
+        # _format_radio_info / _on_state_change and the HINT_STATES /
+        # _RADIO_INFO_STATES class attributes (workers, retranslate_ui and
+        # HandsetController call these by name).
+        import importlib
+        try:
+            gm = importlib.import_module("gui_main")
+        except ImportError:
+            self.skipTest("gui_main not importable in this environment")
+        for name in ("_set_hint", "_compute_hint_state", "_get_hint_copy",
+                     "_format_radio_info", "_on_state_change"):
+            self.assertTrue(hasattr(gm.FlasherFrame, name),
+                            f"frame lost delegator {name}")
+        self.assertTrue(hasattr(gm.FlasherFrame, "HINT_STATES"))
+        self.assertTrue(hasattr(gm.FlasherFrame, "_RADIO_INFO_STATES"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Slice 1 of [`openspec/changes/decompose-gui-main-workers`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/decompose-gui-main-workers/proposal.md): the hint state machine and per-radio info rendering move from `FlasherFrame` into a new `gui_hints.py` (`HintPresenter` + pure `format_radio_info` / `format_variant_prompt`), following the established extraction pattern — the frame keeps thin same-named delegators (`_set_hint`, `_compute_hint_state`, `_format_radio_info`, `_on_state_change`, …) so worker-thread `wx.CallAfter` chains, `HandsetController`, `gui_columns`, and `retranslate_ui` are untouched.

Boundary call worth reviewing: the hardware-variant **prompt text** moved (it composes into the info block); the variant **answer widgets** (`_render_variant_options` etc.) stayed on the frame because they're driven by firmware discovery — slice 2's territory — and manipulate live wx controls. Documented in the module docstring.

- No behavior change; rendered strings byte-identical (logic moved verbatim into the pure helpers).
- `gui_main.py`: 2,074 → **1,978** lines. New module: 208 lines.
- Suite: 207 → **215** (8 new headless tests: hint-state transitions, radio-info formatting for grouped and ungrouped radios). Smoke launch clean.

Slices 2 (download controller) and 3 (flash controller, hardware-gated) follow as their own PRs.

Implemented by an Opus agent from the OpenSpec scaffold (reconciled against the since-merged variant-walkthrough code); reviewed and changelog added by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD