### PR TITLE
Extract download worker and firmware discovery into gui_download (slice 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Architecture
 
+- **Firmware download and update-check extracted from the main frame** (`gui_download.py`, decomposition slice 2 of 3). The download worker, firmware discovery (manifest + variant gating), and the updater/manifest background tasks now live in a `DownloadController` with headless tests over a stub frame and fake downloader; the frame keeps same-named delegators and a read-only `manifest` property shim. `gui_main.py` drops to ~1,826 lines. Behavior unchanged.
 - **Hint/info rendering extracted from the main frame** (`gui_hints.py`, decomposition slice 1 of 3). The hint state machine and per-radio info panel — including the hardware-variant prompt text — now live in a `HintPresenter` with pure, headlessly tested formatting functions; the frame keeps thin same-named delegators so worker threads and sibling components are untouched. `gui_main.py` drops to ~1,978 lines. Behavior unchanged.
 
 ### Test reports

--- a/gui_download.py
+++ b/gui_download.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+Firmware acquisition + update notification: the download/updater controller.
+
+This is the *controller* half of the Firmware column's runtime — everything
+that reaches the network or the filesystem to get firmware onto the machine,
+plus the "a newer app release exists" status-bar notification. It owns:
+
+  * **Firmware discovery** — ``get_firmware_url_and_version`` (manifest-first URL
+    / version resolution) and ``update_radio_info`` (Download button label /
+    enabled state for the current selection, variant-walkthrough refresh, hint
+    refresh), driven by the radio dropdown via ``on_radio_changed``.
+  * **The download worker** — ``on_download`` (confirmation / untested gate /
+    ``_busy`` interlock) and its background ``download_thread`` (network fetch +
+    extract, progress scaled to 80 % for the download phase), plus ``on_browse``
+    for picking a local ``.kdhx``.
+  * **Background tasks** — ``fetch_manifest`` and ``check_update`` run on daemon
+    threads at startup; ``notify_update`` / ``show_update_link`` surface a newer
+    release as a clickable status-bar link.
+
+``DownloadController`` collaborates with the owning frame for everything only
+the frame can provide: the ``download_btn`` / ``file_path`` / ``radio_combo`` /
+``progress`` / ``log`` / ``update_link`` / ``status_bar_panel`` widgets (built by
+gui_columns / gui_statusbar), the ``_busy`` / ``_busy_state`` / ``_terminal_state``
+/ ``_closing`` flags it shares with the flash workers, the worker plumbing
+(``set_buttons`` / ``set_progress`` / ``log_msg``), the hint refresh
+(``_compute_hint_state`` / ``_set_hint``) and workflow gating, and the selection
+model. ``self.manifest`` is owned here and exposed on the frame as a read-only
+``manifest`` property shim (exactly as ``_handset_ports`` shims ``handset.ports``)
+so the hint presenter and flash workers keep reading ``frame.manifest``.
+
+Boundary note — the selection model stays on the frame. ``_get_selected_radio``
+and ``_driver_for`` are shared by HandsetController, the hint presenter and the
+flash workers, so they remain frame-level helpers, not owned here. The
+hardware-variant **answer widgets** (``_render_variant_options`` /
+``_clear_variant_panel`` / ``_on_variant_chosen`` / ``_get_selected_group``) also
+stay on the frame: although firmware discovery drives them, they manipulate the
+frame-owned ``_variant_panel`` and form one selection cluster with
+``_get_selected_radio`` / ``_selected_row`` / ``_radio_rows``. ``update_radio_info``
+reaches back through the frame for them, matching how HandsetController calls
+``frame._driver_for``.
+
+The frame keeps thin same-named delegators (``on_download`` / ``on_browse`` /
+``on_radio_changed`` / ``_update_radio_info`` / ``_get_firmware_url_and_version``
+and the background-task methods) so gui_columns event bindings, the hint
+presenter, the flash workers and the ``__init__`` daemon-thread targets keep
+calling the same names, exactly as HandsetController's delegators do.
+"""
+
+import threading
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+import firmware_download as dl
+import firmware_manifest as fm
+import updater
+from i18n import t
+
+
+class DownloadController:
+    """Owns firmware discovery, the download worker, and update notification."""
+
+    def __init__(self, frame):
+        self.frame = frame
+        # Manifest state (must be resolvable before the first update_radio_info).
+        # The frame exposes this as a read-only `manifest` property shim so the
+        # hint presenter and flash workers keep reading frame.manifest.
+        self.manifest = None
+        self._update_url = None   # set by notify_update when an update is detected
+
+    # ------------------------------------------------------------------
+    # Background tasks
+    # ------------------------------------------------------------------
+
+    def fetch_manifest(self):
+        try:
+            self.manifest = fm.fetch_manifest()
+            wx.CallAfter(self.update_radio_info)
+        except Exception:
+            pass
+
+    def check_update(self):
+        """Background check for a newer release; surface as a status-bar link.
+
+        We deliberately don't try to apply the update in-app — auto-update on
+        Linux git installs has historically been unreliable. Instead, when a
+        newer version is detected we show a clickable link in the status bar
+        that opens the GitHub releases page in the user's default browser.
+        """
+        import time
+        time.sleep(2)  # Let the UI finish rendering before touching the status bar
+        try:
+            has_update, local_info, remote_info = updater.check_for_update()
+            if has_update:
+                wx.CallAfter(self.notify_update, local_info, remote_info)
+        except Exception:
+            pass
+
+    def notify_update(self, local_info, remote_info):
+        """An update is available — show the Update Available link in the status bar."""
+        frame = self.frame
+        if frame._closing or not frame:
+            return
+        # Single source of truth for the running version lives in gui_main;
+        # deferred import avoids a circular import at module load (matches
+        # updater.get_current_version's pattern).
+        from gui_main import VERSION
+        url = updater.get_releases_url()
+        self._update_url = url
+        try:
+            frame.update_link.SetURL(url)
+            frame.update_link.SetToolTip(
+                t("statusbar.update_tooltip").format(
+                    local=VERSION, remote=remote_info)
+            )
+            self.show_update_link()
+        except Exception:
+            pass
+
+    def show_update_link(self):
+        frame = self.frame
+        # The link was added to the sizer while hidden, which caches a 0-width
+        # slot and clips the label on Show(). Re-pin the min size to the
+        # current best size so longer translations (e.g. "Mise à jour disponible")
+        # render in full.
+        frame.update_link.Show()
+        try:
+            frame.update_link.SetMinSize(frame.update_link.GetBestSize())
+        except Exception:
+            pass
+        frame.status_bar_panel.Layout()
+
+    # ------------------------------------------------------------------
+    # Firmware discovery
+    # ------------------------------------------------------------------
+
+    def get_firmware_url_and_version(self, radio):
+        """Get the best firmware URL and version for a radio.
+
+        Checks manifest first (may have newer URL), falls back to radios.json.
+        Returns (url, version) where either may be None.
+        """
+        manifest_info = fm.get_radio_firmware_info(radio["id"], self.manifest)
+        manifest_url = manifest_info.get("firmware_url") if manifest_info else None
+        manifest_ver = manifest_info.get("firmware_version") if manifest_info else None
+
+        url = manifest_url or radio.get("firmware_url")
+        version = manifest_ver
+        return url, version
+
+    def update_radio_info(self):
+        """Refresh the Download button label/state for the selected radio.
+
+        Per-radio info (bootloader keys, connector, notes) is rendered inline
+        in the hints panel via _set_hint(); this method owns the Download
+        button, the hint refresh, and the variant walkthrough panel.
+        """
+        frame = self.frame
+        # May be posted from the background manifest fetch after the frame has
+        # started closing — bail rather than touch destroyed widgets.
+        if frame._closing or not frame:
+            return
+        radio = frame._get_selected_radio()
+        group_sel = frame._get_selected_group()
+        # A variant family row keeps its answer controls visible (so the user
+        # can correct a mis-click) whether or not the variant is resolved yet.
+        if group_sel:
+            frame._render_variant_options(*group_sel)
+        else:
+            frame._clear_variant_panel()
+
+        if radio:
+            # Concrete radio (plain row, or a group with a resolved variant).
+            url, version = self.get_firmware_url_and_version(radio)
+            has_url = bool(url)
+            # Never re-enable Download during an in-progress operation; the
+            # busy-end gating pass will restore the correct state.
+            if not frame._busy:
+                frame.download_btn.Enable(has_url)
+            if not has_url:
+                frame.download_btn.SetLabel(t("button.no_direct_url"))
+            elif version:
+                frame.download_btn.SetLabel(
+                    t("button.download_versioned").format(version=version))
+            else:
+                frame.download_btn.SetLabel(t("button.download_latest"))
+        elif group_sel:
+            # A variant family is selected but not resolved ("I'm not sure" or
+            # unanswered): keep Download disabled until a variant is chosen.
+            if not frame._busy:
+                frame.download_btn.Enable(False)
+            frame.download_btn.SetLabel(t("button.identify_first"))
+
+        frame._set_hint(frame._compute_hint_state())
+
+    def on_radio_changed(self, event):
+        frame = self.frame
+        # Picking a different radio clears any sticky terminal state so the
+        # hint panel doesn't keep showing the previous flash's completion copy.
+        frame._terminal_state = None
+        self.update_radio_info()
+        frame._update_workflow_gating()
+
+    # ------------------------------------------------------------------
+    # Download worker
+    # ------------------------------------------------------------------
+
+    def on_download(self, event):
+        frame = self.frame
+        if frame._busy:
+            return
+        # _get_selected_radio() returns None for an unresolved variant group
+        # (unanswered or "I'm not sure"), so this guard also refuses to start a
+        # download until the user has identified their hardware variant — belt
+        # and suspenders behind the disabled Download button. The app never
+        # guesses; the concrete member id resolves only after an explicit answer.
+        radio = frame._get_selected_radio()
+        if not radio:
+            return
+
+        if not radio.get("tested"):
+            dlg = wx.MessageDialog(frame,
+                t("dialog.untested_body").format(radio=radio['name']),
+                t("dialog.untested_title"), wx.YES_NO | wx.ICON_WARNING)
+            if dlg.ShowModal() != wx.ID_YES:
+                dlg.Destroy()
+                return
+            dlg.Destroy()
+
+        url, _ = self.get_firmware_url_and_version(radio)
+
+        # Get expected SHA-256 from manifest if available
+        manifest_info = fm.get_radio_firmware_info(radio["id"], self.manifest)
+        expected_sha256 = manifest_info.get("firmware_sha256") if manifest_info else None
+
+        frame.log.Clear()
+        frame.progress.SetValue(0)
+        frame._busy = True
+        frame._busy_state = "downloading"
+        frame._terminal_state = None
+        frame.set_buttons(False)
+        frame._set_hint("downloading")
+        threading.Thread(target=self.download_thread,
+                         args=(radio, url, expected_sha256), daemon=True).start()
+
+    def download_thread(self, radio, url=None, expected_sha256=None):
+        frame = self.frame
+        try:
+            frame.log_msg(t("log.downloading_for").format(radio=radio['name']))
+            frame.log_msg(t("log.url").format(url=url or radio.get('firmware_url', 'N/A')))
+            frame.log_msg("")
+
+            def on_progress(pct):
+                frame.set_progress(pct * 0.8)  # 80% for download
+
+            # Use url as override if it differs from the hardcoded one
+            url_override = url if url != radio.get("firmware_url") else None
+            kdhx_path, _ = dl.download_and_extract(
+                radio["id"], progress_callback=on_progress,
+                url_override=url_override,
+                expected_sha256=expected_sha256,
+            )
+
+            frame.set_progress(100)
+            frame.log_msg(t("log.firmware_extracted").format(path=kdhx_path))
+            frame.log_msg("")
+            frame.log_msg(t("log.firmware_ready"))
+
+            wx.CallAfter(frame.file_path.SetValue, kdhx_path)
+            frame._terminal_state = None  # path change will recompute hint
+
+        except Exception as e:
+            frame.log_msg(t("log.error_prefix").format(message=e))
+            if "No direct download URL" in str(e):
+                page = radio.get("firmware_page", "")
+                if page:
+                    frame.log_msg(t("log.visit_page").format(url=page))
+            frame._terminal_state = "failed"
+        finally:
+            frame._busy = False
+            frame.set_buttons(True)
+
+    def on_browse(self, event):
+        frame = self.frame
+        dlg = wx.FileDialog(frame, t("filedlg.select_firmware"),
+                            wildcard=t("filedlg.wildcard"),
+                            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
+        if dlg.ShowModal() == wx.ID_OK:
+            frame.file_path.SetValue(dlg.GetPath())
+        dlg.Destroy()
+        frame._terminal_state = None
+        frame._set_hint(frame._compute_hint_state())

--- a/gui_main.py
+++ b/gui_main.py
@@ -19,7 +19,6 @@ import firmware_manifest as fm
 import firmware_version as fv
 import i18n
 from i18n import t, t_radio_field, t_variant_field
-import updater
 import serial
 
 from gui_dialogs import (
@@ -39,6 +38,7 @@ from gui_columns import (
     FirmwareColumn, HandsetColumn, FlashColumn, radio_display_name,
 )
 from gui_hints import HintPresenter
+from gui_download import DownloadController
 from gui_handset import (
     HandsetController,
     # Flash-worker status values (i18n keys) — comparisons use these symbolic
@@ -99,7 +99,11 @@ class FlasherFrame(wx.Frame):
         # Instructions-panel presentation (hint state machine + per-radio info)
         # lives in HintPresenter; the frame exposes thin delegators below.
         self.hints = HintPresenter(self)
-        self._update_url = None       # set by _check_update when an update is detected
+        # Firmware acquisition + update notification (download worker, firmware
+        # discovery, updater/manifest background tasks) lives in
+        # DownloadController; the frame exposes thin delegators below and a
+        # `manifest` property shim over the controller.
+        self.download = DownloadController(self)
 
         # Window icon
         icon_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icon_128.png")
@@ -117,8 +121,9 @@ class FlasherFrame(wx.Frame):
         # ---- Top row: three columns separated by ">" arrows ----
         top_row = wx.BoxSizer(wx.HORIZONTAL)
 
-        # Manifest state (must be set before _update_radio_info)
-        self.manifest = None
+        # Manifest state is owned by DownloadController (constructed above, so
+        # it's resolvable before the first _update_radio_info) and exposed here
+        # via the `manifest` property shim.
         self.radios = dl.load_radios()
         # Hardware-variant groups collapse their sibling members into one
         # dropdown "family" row. _variant_choice maps a group id to the
@@ -947,60 +952,22 @@ class FlasherFrame(wx.Frame):
         event.Skip()
 
     # ------------------------------------------------------------------
-    # Background tasks
+    # Background tasks — behavior in DownloadController (gui_download).
+    # These thin wrappers keep the __init__ daemon-thread targets and the
+    # wx.CallAfter update-notification chain calling the same names.
     # ------------------------------------------------------------------
 
     def _fetch_manifest(self):
-        try:
-            self.manifest = fm.fetch_manifest()
-            wx.CallAfter(self._update_radio_info)
-        except Exception:
-            pass
+        self.download.fetch_manifest()
 
     def _check_update(self):
-        """Background check for a newer release; surface as a status-bar link.
-
-        We deliberately don't try to apply the update in-app — auto-update on
-        Linux git installs has historically been unreliable. Instead, when a
-        newer version is detected we show a clickable link in the status bar
-        that opens the GitHub releases page in the user's default browser.
-        """
-        import time
-        time.sleep(2)  # Let the UI finish rendering before touching the status bar
-        try:
-            has_update, local_info, remote_info = updater.check_for_update()
-            if has_update:
-                wx.CallAfter(self._notify_update, local_info, remote_info)
-        except Exception:
-            pass
+        self.download.check_update()
 
     def _notify_update(self, local_info, remote_info):
-        """An update is available — show the Update Available link in the status bar."""
-        if self._closing or not self:
-            return
-        url = updater.get_releases_url()
-        self._update_url = url
-        try:
-            self.update_link.SetURL(url)
-            self.update_link.SetToolTip(
-                t("statusbar.update_tooltip").format(
-                    local=VERSION, remote=remote_info)
-            )
-            self._show_update_link()
-        except Exception:
-            pass
+        self.download.notify_update(local_info, remote_info)
 
     def _show_update_link(self):
-        # The link was added to the sizer while hidden, which caches a 0-width
-        # slot and clips the label on Show(). Re-pin the min size to the
-        # current best size so longer translations (e.g. "Mise à jour disponible")
-        # render in full.
-        self.update_link.Show()
-        try:
-            self.update_link.SetMinSize(self.update_link.GetBestSize())
-        except Exception:
-            pass
-        self.status_bar_panel.Layout()
+        self.download.show_update_link()
 
     def _radio_rows(self):
         """Ordered dropdown rows, one per line the combo shows (excluding the
@@ -1089,153 +1056,34 @@ class FlasherFrame(wx.Frame):
         proto = (radio or {}).get("protocol", "kdh")
         return fw_btf if proto == "btf" else fw
 
+    # --- Firmware discovery + download worker + updater: behavior delegated to
+    # DownloadController (gui_download). These thin wrappers keep the existing
+    # call sites (gui_columns bindings, hint presenter, flash workers,
+    # retranslate_ui, __init__) calling the same names while the logic lives in
+    # the controller. `manifest` is a property shim over the controller, exactly
+    # as `_handset_ports` shims `handset.ports`.
+
+    @property
+    def manifest(self):
+        return self.download.manifest
+
     def _get_firmware_url_and_version(self, radio):
-        """Get the best firmware URL and version for a radio.
-
-        Checks manifest first (may have newer URL), falls back to radios.json.
-        Returns (url, version) where either may be None.
-        """
-        manifest_info = fm.get_radio_firmware_info(radio["id"], self.manifest)
-        manifest_url = manifest_info.get("firmware_url") if manifest_info else None
-        manifest_ver = manifest_info.get("firmware_version") if manifest_info else None
-
-        url = manifest_url or radio.get("firmware_url")
-        version = manifest_ver
-        return url, version
+        return self.download.get_firmware_url_and_version(radio)
 
     def _update_radio_info(self):
-        """Refresh the Download button label/state for the selected radio.
-
-        Per-radio info (bootloader keys, connector, notes) is rendered inline
-        in the hints panel via _set_hint(); this method owns the Download
-        button, the hint refresh, and the variant walkthrough panel.
-        """
-        # May be posted from the background manifest fetch after the frame has
-        # started closing — bail rather than touch destroyed widgets.
-        if self._closing or not self:
-            return
-        radio = self._get_selected_radio()
-        group_sel = self._get_selected_group()
-        # A variant family row keeps its answer controls visible (so the user
-        # can correct a mis-click) whether or not the variant is resolved yet.
-        if group_sel:
-            self._render_variant_options(*group_sel)
-        else:
-            self._clear_variant_panel()
-
-        if radio:
-            # Concrete radio (plain row, or a group with a resolved variant).
-            url, version = self._get_firmware_url_and_version(radio)
-            has_url = bool(url)
-            # Never re-enable Download during an in-progress operation; the
-            # busy-end gating pass will restore the correct state.
-            if not self._busy:
-                self.download_btn.Enable(has_url)
-            if not has_url:
-                self.download_btn.SetLabel(t("button.no_direct_url"))
-            elif version:
-                self.download_btn.SetLabel(
-                    t("button.download_versioned").format(version=version))
-            else:
-                self.download_btn.SetLabel(t("button.download_latest"))
-        elif group_sel:
-            # A variant family is selected but not resolved ("I'm not sure" or
-            # unanswered): keep Download disabled until a variant is chosen.
-            if not self._busy:
-                self.download_btn.Enable(False)
-            self.download_btn.SetLabel(t("button.identify_first"))
-
-        self._set_hint(self._compute_hint_state())
+        self.download.update_radio_info()
 
     def on_radio_changed(self, event):
-        # Picking a different radio clears any sticky terminal state so the
-        # hint panel doesn't keep showing the previous flash's completion copy.
-        self._terminal_state = None
-        self._update_radio_info()
-        self._update_workflow_gating()
+        self.download.on_radio_changed(event)
 
     def on_download(self, event):
-        if self._busy:
-            return
-        # _get_selected_radio() returns None for an unresolved variant group
-        # (unanswered or "I'm not sure"), so this guard also refuses to start a
-        # download until the user has identified their hardware variant — belt
-        # and suspenders behind the disabled Download button. The app never
-        # guesses; the concrete member id resolves only after an explicit answer.
-        radio = self._get_selected_radio()
-        if not radio:
-            return
-
-        if not radio.get("tested"):
-            dlg = wx.MessageDialog(self,
-                t("dialog.untested_body").format(radio=radio['name']),
-                t("dialog.untested_title"), wx.YES_NO | wx.ICON_WARNING)
-            if dlg.ShowModal() != wx.ID_YES:
-                dlg.Destroy()
-                return
-            dlg.Destroy()
-
-        url, _ = self._get_firmware_url_and_version(radio)
-
-        # Get expected SHA-256 from manifest if available
-        manifest_info = fm.get_radio_firmware_info(radio["id"], self.manifest)
-        expected_sha256 = manifest_info.get("firmware_sha256") if manifest_info else None
-
-        self.log.Clear()
-        self.progress.SetValue(0)
-        self._busy = True
-        self._busy_state = "downloading"
-        self._terminal_state = None
-        self.set_buttons(False)
-        self._set_hint("downloading")
-        threading.Thread(target=self._download_thread,
-                         args=(radio, url, expected_sha256), daemon=True).start()
+        self.download.on_download(event)
 
     def _download_thread(self, radio, url=None, expected_sha256=None):
-        try:
-            self.log_msg(t("log.downloading_for").format(radio=radio['name']))
-            self.log_msg(t("log.url").format(url=url or radio.get('firmware_url', 'N/A')))
-            self.log_msg("")
-
-            def on_progress(pct):
-                self.set_progress(pct * 0.8)  # 80% for download
-
-            # Use url as override if it differs from the hardcoded one
-            url_override = url if url != radio.get("firmware_url") else None
-            kdhx_path, _ = dl.download_and_extract(
-                radio["id"], progress_callback=on_progress,
-                url_override=url_override,
-                expected_sha256=expected_sha256,
-            )
-
-            self.set_progress(100)
-            self.log_msg(t("log.firmware_extracted").format(path=kdhx_path))
-            self.log_msg("")
-            self.log_msg(t("log.firmware_ready"))
-
-            wx.CallAfter(self.file_path.SetValue, kdhx_path)
-            self._terminal_state = None  # path change will recompute hint
-
-        except Exception as e:
-            self.log_msg(t("log.error_prefix").format(message=e))
-            if "No direct download URL" in str(e):
-                page = radio.get("firmware_page", "")
-                if page:
-                    self.log_msg(t("log.visit_page").format(url=page))
-            self._terminal_state = "failed"
-        finally:
-            self._busy = False
-            self.set_buttons(True)
+        self.download.download_thread(radio, url, expected_sha256)
 
     def on_browse(self, event):
-        dlg = wx.FileDialog(self, t("filedlg.select_firmware"),
-                            wildcard=t("filedlg.wildcard"),
-                            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
-        if dlg.ShowModal() == wx.ID_OK:
-            self.file_path.SetValue(dlg.GetPath())
-        dlg.Destroy()
-        self._terminal_state = None
-        self._set_hint(self._compute_hint_state())
+        self.download.on_browse(event)
 
     def log_msg(self, msg):
         wx.CallAfter(self.log.AppendText, msg + "\n")

--- a/tests.py
+++ b/tests.py
@@ -2402,5 +2402,228 @@ class TestHintPresenterModule(unittest.TestCase):
         self.assertTrue(hasattr(gm.FlasherFrame, "_RADIO_INFO_STATES"))
 
 
+class TestDownloadController(unittest.TestCase):
+    """Headless coverage of the extracted DownloadController (gui_download).
+
+    The controller drives widgets only through the frame, so we bind it to a
+    lightweight stub with fake widgets / plumbing instead of a wx.Frame (which
+    needs a display). This exercises the firmware-discovery resolution (manifest
+    vs radios.json, variant-gated Download label/state) and the download worker's
+    progress scaling / terminal-state transitions with a fake ``dl``. No display,
+    no network, no pyserial — following the enumerate_serial_ports /
+    format_radio_info precedent."""
+
+    def setUp(self):
+        try:
+            import gui_download
+            import i18n
+        except ImportError:
+            self.skipTest("gui_download / i18n not importable")
+        i18n.load_bundled_en()
+        self.gd = gui_download
+        self.i18n = i18n
+
+    # -- small fakes ----------------------------------------------------- #
+    class _FakeButton:
+        def __init__(self):
+            self.enabled = None
+            self.label = None
+
+        def Enable(self, flag=True):
+            self.enabled = flag
+
+        def SetLabel(self, text):
+            self.label = text
+
+    class _FakeText:
+        def __init__(self):
+            self.value = None
+
+        def SetValue(self, v):
+            self.value = v
+
+        def Clear(self):
+            self.value = ""
+
+    def _stub_frame(self, **overrides):
+        """A SimpleNamespace frame with the collaborators the controller reads.
+
+        Records log lines, progress values, set_buttons calls and hint states so
+        assertions can inspect what the worker posted."""
+        f = types.SimpleNamespace()
+        f._closing = False
+        f._busy = False
+        f._busy_state = None
+        f._terminal_state = "sentinel"
+        f.download_btn = self._FakeButton()
+        f.file_path = self._FakeText()
+        f.log = self._FakeText()
+        f.progress_values = []
+        f.log_lines = []
+        f.set_buttons_calls = []
+        f.hint_states = []
+        f.set_progress = lambda pct: f.progress_values.append(pct)
+        f.log_msg = lambda msg: f.log_lines.append(msg)
+        f.set_buttons = lambda enabled: f.set_buttons_calls.append(enabled)
+        f._set_hint = lambda state: f.hint_states.append(state)
+        f._compute_hint_state = lambda: "computed"
+        f._update_workflow_gating = lambda: None
+        f._render_variant_options = lambda *a: setattr(f, "rendered_group", a)
+        f._clear_variant_panel = lambda: setattr(f, "variant_cleared", True)
+        f._get_selected_radio = lambda: None
+        f._get_selected_group = lambda: None
+        for k, v in overrides.items():
+            setattr(f, k, v)
+        return f
+
+    class _FakeCallAfterWx:
+        """Stand-in for the wx module: CallAfter runs synchronously so the
+        headless test can assert on the resulting widget writes."""
+        @staticmethod
+        def CallAfter(func, *args, **kwargs):
+            func(*args, **kwargs)
+
+    def _controller(self, frame):
+        dc = self.gd.DownloadController(frame)
+        return dc
+
+    # -- module surface / delegators ------------------------------------- #
+    def test_module_exposes_controller(self):
+        self.assertTrue(hasattr(self.gd, "DownloadController"))
+
+    def test_frame_keeps_same_named_delegators(self):
+        import importlib
+        try:
+            gm = importlib.import_module("gui_main")
+        except ImportError:
+            self.skipTest("gui_main not importable in this environment")
+        for name in ("on_download", "on_browse", "on_radio_changed",
+                     "_update_radio_info", "_get_firmware_url_and_version",
+                     "_download_thread", "_fetch_manifest", "_check_update",
+                     "_notify_update", "_show_update_link"):
+            self.assertTrue(hasattr(gm.FlasherFrame, name),
+                            f"frame lost delegator {name}")
+        # manifest is a property shim over the controller (not a plain attr).
+        self.assertIsInstance(gm.FlasherFrame.manifest, property)
+
+    # -- firmware discovery ---------------------------------------------- #
+    def test_manifest_url_and_version_win_over_radios_json(self):
+        dc = self._controller(self._stub_frame())
+        dc.manifest = {"acme-x1": {"firmware_version": "1.2",
+                                   "firmware_url": "https://example.com/new.zip"}}
+        radio = {"id": "acme-x1",
+                 "firmware_url": "https://example.com/old.zip"}
+        url, version = dc.get_firmware_url_and_version(radio)
+        self.assertEqual(url, "https://example.com/new.zip")
+        self.assertEqual(version, "1.2")
+
+    def test_falls_back_to_radios_json_without_manifest(self):
+        dc = self._controller(self._stub_frame())
+        dc.manifest = None
+        radio = {"id": "acme-x1",
+                 "firmware_url": "https://example.com/old.zip"}
+        url, version = dc.get_firmware_url_and_version(radio)
+        self.assertEqual(url, "https://example.com/old.zip")
+        self.assertIsNone(version)
+
+    # -- update_radio_info: variant-gated + concrete paths --------------- #
+    def test_update_radio_info_gates_unresolved_variant_group(self):
+        t = self.i18n.t
+        group = ("acme-family", {"name": "Acme Fam", "manufacturer": "Acme"})
+        frame = self._stub_frame(
+            _get_selected_radio=lambda: None,
+            _get_selected_group=lambda: group,
+        )
+        dc = self._controller(frame)
+        dc.update_radio_info()
+        # Family answer controls are (re)rendered, Download stays disabled with
+        # the "identify first" label, and the hint is refreshed.
+        self.assertEqual(frame.rendered_group, group)
+        self.assertFalse(frame.download_btn.enabled)
+        self.assertEqual(frame.download_btn.label, t("button.identify_first"))
+        self.assertEqual(frame.hint_states[-1], "computed")
+
+    def test_update_radio_info_enables_download_for_concrete_radio(self):
+        t = self.i18n.t
+        radio = {"id": "acme-x1", "name": "Acme X1",
+                 "firmware_url": "https://example.com/fw.zip"}
+        frame = self._stub_frame(
+            _get_selected_radio=lambda: radio,
+            _get_selected_group=lambda: None,
+        )
+        dc = self._controller(frame)
+        dc.manifest = {"acme-x1": {"firmware_version": "3.1",
+                                   "firmware_url": "https://example.com/fw.zip"}}
+        dc.update_radio_info()
+        self.assertTrue(frame.variant_cleared)
+        self.assertTrue(frame.download_btn.enabled)
+        self.assertEqual(frame.download_btn.label,
+                         t("button.download_versioned").format(version="3.1"))
+
+    def test_update_radio_info_bails_while_closing(self):
+        frame = self._stub_frame(_closing=True)
+        dc = self._controller(frame)
+        dc.update_radio_info()  # must not touch widgets
+        self.assertIsNone(frame.download_btn.label)
+        self.assertEqual(frame.hint_states, [])
+
+    # -- download worker: progress scaling + terminal state -------------- #
+    def test_download_thread_scales_progress_and_completes(self):
+        frame = self._stub_frame()
+        dc = self._controller(frame)
+        radio = {"id": "acme-x1", "name": "Acme X1",
+                 "firmware_url": "https://example.com/fw.zip"}
+
+        def fake_extract(radio_id, progress_callback=None, url_override=None,
+                         expected_sha256=None):
+            progress_callback(50)   # mid-download
+            return ("/tmp/acme.kdhx", None)
+
+        saved_dl = self.gd.dl
+        saved_wx = self.gd.wx
+        try:
+            self.gd.dl = types.SimpleNamespace(download_and_extract=fake_extract)
+            self.gd.wx = self._FakeCallAfterWx
+            dc.download_thread(radio, url="https://example.com/fw.zip")
+        finally:
+            self.gd.dl = saved_dl
+            self.gd.wx = saved_wx
+
+        # 50% download progress is scaled to 80% of the bar (50 * 0.8 == 40),
+        # then the extract step drives it to 100.
+        self.assertIn(40.0, frame.progress_values)
+        self.assertEqual(frame.progress_values[-1], 100)
+        self.assertEqual(frame.file_path.value, "/tmp/acme.kdhx")
+        self.assertIsNone(frame._terminal_state)   # cleared on success
+        self.assertFalse(frame._busy)
+        self.assertEqual(frame.set_buttons_calls[-1], True)
+
+    def test_download_thread_marks_failure(self):
+        frame = self._stub_frame()
+        dc = self._controller(frame)
+        radio = {"id": "acme-x1", "name": "Acme X1",
+                 "firmware_url": "https://example.com/fw.zip",
+                 "firmware_page": "https://example.com/page"}
+
+        def boom(*a, **k):
+            raise RuntimeError("No direct download URL for this radio")
+
+        saved_dl = self.gd.dl
+        saved_wx = self.gd.wx
+        try:
+            self.gd.dl = types.SimpleNamespace(download_and_extract=boom)
+            self.gd.wx = self._FakeCallAfterWx
+            dc.download_thread(radio, url="https://example.com/fw.zip")
+        finally:
+            self.gd.dl = saved_dl
+            self.gd.wx = saved_wx
+
+        self.assertEqual(frame._terminal_state, "failed")
+        self.assertFalse(frame._busy)
+        self.assertEqual(frame.set_buttons_calls[-1], True)
+        # The firmware_page is surfaced when the URL is missing.
+        self.assertTrue(any("example.com/page" in line for line in frame.log_lines))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Slice 2 of [`openspec/changes/decompose-gui-main-workers`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/decompose-gui-main-workers/proposal.md): the download worker, firmware discovery (`_get_firmware_url_and_version` / `_update_radio_info` incl. the variant-resolution gating), and the updater/manifest background tasks move into a `DownloadController` (`gui_download.py`), on the same controller idiom as `gui_handset`/`gui_hints`. The frame keeps thin same-named delegators for every call site, and `self.manifest` becomes a read-only property shim over controller-owned state.

Boundary call worth reviewing: the variant answer widgets (`_render_variant_options` etc.) **stay on the frame** — they form one selection cluster with `_selected_row`/`_get_selected_radio`, which the design deliberately keeps as shared frame helpers read by handset, hints, and (future) flash controllers; the DownloadController reaches back through the frame for them, exactly as `HandsetController` does for `_driver_for`. Documented in the module docstring.

- No behavior change; slice 3's serial workers untouched.
- `gui_main.py`: 1,978 → **1,826** lines. New module: 295 lines.
- Suite: 215 → **224** (9 new headless `TestDownloadController` tests: discovery paths, variant-gated vs concrete Download states, closing-guard, progress scaling, terminal states — stub frame + fake `dl`, no network/display). Smoke launch clean.

Slice 3 (flash controller — serial worker threads) follows as a draft PR held for a hardware checklist, per the proposal.

Implemented by an Opus agent from the OpenSpec scaffold; reviewed and changelog added by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD