### PR TITLE
Extract flash/dry-run/diag workers into gui_flash + driver convergence (slice 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Architecture
 
+- **Flash/dry-run/diagnostics workers extracted from the main frame** (`gui_flash.py`, decomposition slice 3 of 3) and converged onto the driver functions (`flash_to_port` / `dry_run` / new `diagnostic_probe`), giving the single-flash, dry-run, and diagnostics paths their first headless mock-bootloader coverage. That new coverage immediately caught an `UnboundLocalError` introduced on master by the test-report wiring (`os.path.basename` before a function-local `import os`) that broke single-handset flashing — fixed here before any release shipped it. `gui_main.py` drops to ~1,188 lines (from ~2,305 at the start of the decomposition).
 - **Firmware download and update-check extracted from the main frame** (`gui_download.py`, decomposition slice 2 of 3). The download worker, firmware discovery (manifest + variant gating), and the updater/manifest background tasks now live in a `DownloadController` with headless tests over a stub frame and fake downloader; the frame keeps same-named delegators and a read-only `manifest` property shim. `gui_main.py` drops to ~1,826 lines. Behavior unchanged.
 - **Hint/info rendering extracted from the main frame** (`gui_hints.py`, decomposition slice 1 of 3). The hint state machine and per-radio info panel — including the hardware-variant prompt text — now live in a `HintPresenter` with pure, headlessly tested formatting functions; the frame keeps thin same-named delegators so worker threads and sibling components are untouched. `gui_main.py` drops to ~1,978 lines. Behavior unchanged.
 

--- a/flash_btf.py
+++ b/flash_btf.py
@@ -245,6 +245,55 @@ def probe_port(port: str, timeout: float = 1.5) -> bool:
         return False
 
 
+def diagnostic_probe(port: str, timeout: float = 1.0) -> dict:
+    """Open ``port``, send one BTF CMD_PROBE, and report the raw exchange.
+
+    Mirrors ``flash_firmware.diagnostic_probe`` so the GUI diagnostics worker
+    can dispatch with the same callable shape via ``_driver_for``. Returns the
+    same dict shape ``{baudrate, dtr, rts, cts, dsr, tx_hex, rx_count, rx_hex,
+    responding}``; any bytes back count as "responding". Raises on serial-open
+    errors so the caller can surface the dialout hint.
+    """
+    if serial is None:
+        raise RuntimeError("pyserial not installed; cannot open serial ports")
+
+    with serial.Serial(
+        port=port, baudrate=115200, bytesize=8,
+        parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
+        timeout=timeout
+    ) as ser:
+        ser.dtr = True
+        ser.rts = True
+        time.sleep(0.1)
+
+        info = {
+            "baudrate": ser.baudrate,
+            "dtr": ser.dtr,
+            "rts": ser.rts,
+            "cts": ser.cts,
+            "dsr": ser.dsr,
+        }
+
+        packet = build_packet(CMD_PROBE)
+        info["tx_hex"] = packet.hex()
+        ser.reset_input_buffer()
+        ser.write(packet)
+        ser.flush()
+
+        time.sleep(1.0)
+        avail = ser.in_waiting
+        if avail:
+            data = ser.read(min(avail, 128))
+            info["rx_count"] = avail
+            info["rx_hex"] = data.hex()
+            info["responding"] = True
+        else:
+            info["rx_count"] = 0
+            info["rx_hex"] = ""
+            info["responding"] = False
+    return info
+
+
 def flash_to_port(port: str, btf_bytes: bytes,
                   log_cb=None, progress_cb=None) -> None:
     """Flash an already-loaded .BTF file to a single radio on `port`.

--- a/flash_firmware.py
+++ b/flash_firmware.py
@@ -275,6 +275,59 @@ def probe_port(port: str, timeout: float = 1.5) -> bool:
         return False
 
 
+def diagnostic_probe(port: str, timeout: float = 1.0) -> dict:
+    """Open ``port``, send one KDH handshake, and report the raw exchange.
+
+    The single-shot probe the GUI diagnostics worker drives: it surfaces the
+    serial line state and whether the radio answered at all (any bytes back =
+    "responding"), without the multi-test CLI ``run_diagnostics`` flow. Returns
+    a dict the GUI formats into its i18n diagnostics log::
+
+        {baudrate, dtr, rts, cts, dsr, tx_hex, rx_count, rx_hex, responding}
+
+    Raises on serial-open errors (e.g. PermissionError) so the caller can show
+    the dialout hint, exactly as the previous inline worker did.
+    """
+    if serial is None:
+        raise RuntimeError("pyserial not installed; cannot open serial ports")
+
+    with serial.Serial(
+        port=port, baudrate=115200, bytesize=8,
+        parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
+        timeout=timeout
+    ) as ser:
+        ser.dtr = True
+        ser.rts = True
+        time.sleep(0.1)
+
+        info = {
+            "baudrate": ser.baudrate,
+            "dtr": ser.dtr,
+            "rts": ser.rts,
+            "cts": ser.cts,
+            "dsr": ser.dsr,
+        }
+
+        packet = build_packet(CMD_HANDSHAKE, 0, b"BOOTLOADER")
+        info["tx_hex"] = packet.hex()
+        ser.reset_input_buffer()
+        ser.write(packet)
+        ser.flush()
+
+        time.sleep(1.0)
+        avail = ser.in_waiting
+        if avail:
+            data = ser.read(min(avail, 128))
+            info["rx_count"] = avail
+            info["rx_hex"] = data.hex()
+            info["responding"] = True
+        else:
+            info["rx_count"] = 0
+            info["rx_hex"] = ""
+            info["responding"] = False
+    return info
+
+
 def flash_to_port(port: str, firmware: bytes,
                   log_cb=None, progress_cb=None) -> None:
     """Flash already-loaded firmware bytes to a single radio on `port`.
@@ -483,11 +536,23 @@ def run_diagnostics(port: str):
         print("RESULT: Radio is responding! The flash should work.")
 
 
-def dry_run(firmware_path: str):
-    """Verify packet construction without touching serial port."""
+def dry_run(firmware_path: str, log_cb=None) -> bool:
+    """Verify packet construction without touching serial port.
+
+    ``log_cb(str)`` overrides ``print()`` for GUI integration (mirrors
+    ``flash_btf.dry_run``); the CLI leaves it None and keeps printing. The GUI
+    dry-run worker routes its log through here instead of hand-rolling the same
+    validation + packet-build + CRC-self-check loop inline.
+    """
+    def _log(msg=""):
+        if log_cb:
+            log_cb(msg)
+        else:
+            print(msg)
+
     fw_size = os.path.getsize(firmware_path)
     if fw_size > MAX_FIRMWARE_BYTES:
-        print(f"FAIL: File too large ({fw_size} bytes, max {MAX_FIRMWARE_BYTES})")
+        _log(f"FAIL: File too large ({fw_size} bytes, max {MAX_FIRMWARE_BYTES})")
         return False
 
     with open(firmware_path, "rb") as f:
@@ -497,42 +562,41 @@ def dry_run(firmware_path: str):
     total_chunks = math.ceil(fw_size / 1024)
 
     if fw_size < MIN_FIRMWARE_BYTES:
-        print(f"FAIL: Firmware too small ({fw_size} bytes)")
+        _log(f"FAIL: Firmware too small ({fw_size} bytes)")
         return False
 
     if total_chunks > MAX_CHUNKS:
-        print(f"FAIL: Too many chunks ({total_chunks}, max {MAX_CHUNKS})")
+        _log(f"FAIL: Too many chunks ({total_chunks}, max {MAX_CHUNKS})")
         return False
 
     sha256 = hashlib.sha256(firmware).hexdigest()
-    print(f"Firmware: {firmware_path}")
-    print(f"Size: {fw_size} bytes, {total_chunks} chunks")
-    print(f"SHA-256: {sha256}")
-    print()
+    _log(f"Firmware: {firmware_path}")
+    _log(f"Size: {fw_size} bytes, {total_chunks} chunks")
+    _log(f"SHA-256: {sha256}")
+    _log()
 
     sp = int.from_bytes(firmware[0:4], "little")
     reset = int.from_bytes(firmware[4:8], "little")
-    print("ARM vector table check:")
-    print(f"  Stack pointer:  0x{sp:08X}", end="")
     ok_sp = 0x20000000 <= sp <= 0x20100000
-    print(" (valid SRAM)" if ok_sp else " (INVALID)")
-    print(f"  Reset handler:  0x{reset:08X}", end="")
     ok_reset = 0x08000000 <= reset <= 0x08100000
-    print(" (valid Flash)" if ok_reset else " (INVALID)")
+    _log("ARM vector table check:")
+    _log(f"  Stack pointer:  0x{sp:08X}" + (" (valid SRAM)" if ok_sp else " (INVALID)"))
+    _log(f"  Reset handler:  0x{reset:08X}" + (" (valid Flash)" if ok_reset else " (INVALID)"))
     if not ok_sp or not ok_reset:
-        print("\nFAIL: Invalid ARM vector table")
+        _log("")
+        _log("FAIL: Invalid ARM vector table")
         return False
-    print()
+    _log()
 
-    print("Building all packets (manual download flow)...")
+    _log("Building all packets (manual download flow)...")
 
     p = build_packet(CMD_HANDSHAKE, 0, b"BOOTLOADER")
-    print(f"  CMD_HANDSHAKE:            {p.hex()}")
+    _log(f"  CMD_HANDSHAKE:            {p.hex()}")
 
     p = build_packet(CMD_UPDATE_DATA_PACKAGES, 0, bytes([total_chunks]))
-    print(f"  CMD_UPDATE_DATA_PACKAGES: {p.hex()} (chunks={total_chunks})")
+    _log(f"  CMD_UPDATE_DATA_PACKAGES: {p.hex()} (chunks={total_chunks})")
 
-    print(f"  CMD_UPDATE:               building {total_chunks} data packets...")
+    _log(f"  CMD_UPDATE:               building {total_chunks} data packets...")
     for i in range(total_chunks):
         offset = i * 1024
         chunk = firmware[offset:offset + 1024]
@@ -543,15 +607,15 @@ def dry_run(firmware_path: str):
         assert crc16_ccitt(payload) == pkt_crc, f"Chunk {i}: CRC self-check failed"
 
     p = build_packet(CMD_UPDATE_END, 0)
-    print(f"  CMD_UPDATE_END:           {p.hex()}")
+    _log(f"  CMD_UPDATE_END:           {p.hex()}")
 
-    print()
-    print(f"Total packets: {total_chunks + 3}")
-    print("All CRC self-checks passed")
+    _log()
+    _log(f"Total packets: {total_chunks + 3}")
+    _log("All CRC self-checks passed")
     last_chunk_size = fw_size - (total_chunks - 1) * 1024
-    print(f"Last chunk: {last_chunk_size} bytes")
-    print()
-    print("DRY RUN PASSED")
+    _log(f"Last chunk: {last_chunk_size} bytes")
+    _log()
+    _log("DRY RUN PASSED")
     return True
 
 

--- a/gui_flash.py
+++ b/gui_flash.py
@@ -216,7 +216,6 @@ class FlashController:
         """
         frame = self.frame
         radio = frame._get_selected_radio()
-        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
 
         # Validate firmware once up front
         driver = frame._driver_for(radio)
@@ -315,7 +314,10 @@ class FlashController:
         # delegate to the BTF-specific path. The KDH inline flow below stays
         # unchanged so existing translations and behavior are preserved.
         if (radio or {}).get("protocol") == "btf":
-            return self.flash_thread_btf(port, firmware_path, handset_idx, radio)
+            # Workers don't return values; call-then-return keeps the exits
+            # uniform instead of propagating the BTF worker's None.
+            self.flash_thread_btf(port, firmware_path, handset_idx, radio)
+            return
 
         # Derive once, up front, so both the success and failure paths pass the
         # same identity to record_flash and to the test-report nag suppression.
@@ -383,6 +385,9 @@ class FlashController:
                     self.log_msg(t("log.recorded_flash").format(
                         version=file_version, radio=radio_name))
                 except Exception:
+                    # Recording flash history is bookkeeping: a corrupt or
+                    # unwritable state file must not fail a flash that already
+                    # succeeded on the radio.
                     pass
                 # Compare against latest known
                 _, latest_ver = frame._get_firmware_url_and_version(radio)
@@ -473,6 +478,8 @@ class FlashController:
                     self.log_msg(t("log.recorded_flash").format(
                         version=file_version, radio=radio_name))
                 except Exception:
+                    # Same as the KDH path: history bookkeeping is best-effort
+                    # and must not fail an already-successful flash.
                     pass
 
             frame._terminal_state = "complete"
@@ -565,6 +572,8 @@ class FlashController:
                     frame._update_workflow_gating()
             dlg.Destroy()
         except Exception:
+            # The cleanup offer is a courtesy prompt after the flash finished;
+            # any dialog/filesystem hiccup here is not worth surfacing.
             pass
 
     # ------------------------------------------------------------------

--- a/gui_flash.py
+++ b/gui_flash.py
@@ -54,11 +54,6 @@ try:
 except ImportError:
     wx = None
 
-try:
-    import serial
-except ImportError:
-    serial = None
-
 import flash_firmware as fw
 import flash_btf as fw_btf
 import firmware_manifest as fm
@@ -333,8 +328,12 @@ class FlashController:
             wx.CallAfter(frame._set_handset_progress, handset_idx, "0%")
 
         try:
+            # `os` is the module-level import (line above uses os.path.basename
+            # before this try); a function-local `import os` here would make os
+            # a local for the whole function and raise UnboundLocalError on that
+            # earlier reference — a latent crash in the pre-convergence inline
+            # worker that had no headless coverage to catch it.
             import math
-            import time
             import hashlib
 
             fw_size = os.path.getsize(firmware_path)
@@ -352,42 +351,24 @@ class FlashController:
             self.log_msg(t("log.port").format(port=port))
             self.log_msg("")
 
-            with serial.Serial(
-                port=port, baudrate=115200, bytesize=8,
-                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                timeout=2.0, write_timeout=2.0
-            ) as ser:
-                ser.dtr = True
-                ser.rts = True
-                time.sleep(0.1)
-                ser.reset_input_buffer()
-                ser.reset_output_buffer()
+            def log_cb(msg):
+                self.log_msg(msg)
 
-                self.log_msg(t("log.step_handshake"))
-                fw.send_command(ser, fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
-                self.log_msg(t("log.step_handshake_ok"))
+            def progress_cb(pct):
+                self.set_progress(pct)
+                if handset_idx is not None:
+                    wx.CallAfter(frame._set_handset_progress,
+                                 handset_idx, f"{int(pct)}%")
 
-                self.log_msg(t("log.step_sending").format(chunks=total_chunks))
-                fw.send_command(ser, fw.CMD_UPDATE_DATA_PACKAGES, 0, bytes([total_chunks]))
+            # Converged onto the mock_bootloader-testable driver function: the
+            # handshake → announce → stream → finalize sequence was hand-rolled
+            # as a serial.Serial + send_command loop inline here, so the single-
+            # flash KDH path had no headless coverage. flash_to_port is the same
+            # on-the-wire flow the batch path already drives; the GUI worker is
+            # now a thin wrapper (validation + preamble/post logging + version
+            # recording + test-report offer) around it.
+            fw.flash_to_port(port, firmware, log_cb=log_cb, progress_cb=progress_cb)
 
-                for i in range(total_chunks):
-                    offset = i * 1024
-                    chunk = firmware[offset:offset + 1024]
-                    if len(chunk) < 1024:
-                        chunk = chunk + b'\x00' * (1024 - len(chunk))
-                    fw.send_command(ser, fw.CMD_UPDATE, i & 0xFF, chunk)
-                    pct = ((i + 1) / total_chunks) * 100
-                    self.set_progress(pct)
-                    if handset_idx is not None:
-                        wx.CallAfter(frame._set_handset_progress, handset_idx, f"{int(pct)}%")
-                    if (i + 1) % 10 == 0 or i == total_chunks - 1:
-                        self.log_msg(t("log.progress_line").format(
-                            pct=f"{pct:.0f}", done=i + 1, total=total_chunks))
-
-                self.log_msg(t("log.step_finalize"))
-                fw.send_command(ser, fw.CMD_UPDATE_END, 0)
-
-            self.log_msg(t("log.step_handshake_ok"))
             self.log_msg("")
             self.log_msg(t("log.flash_complete"))
             self.log_msg(t("log.power_cycle"))
@@ -451,6 +432,9 @@ class FlashController:
 
         sha256 = ""
         try:
+            # Use the module-level `os` (see flash_thread): a function-local
+            # `import os` would UnboundLocalError on the os.path.basename call
+            # above.
             import hashlib
 
             fw_size = os.path.getsize(firmware_path)
@@ -607,100 +591,25 @@ class FlashController:
         threading.Thread(target=self.dryrun_thread, args=(firmware_path,), daemon=True).start()
 
     def dryrun_thread(self, firmware_path):
-        # BTF dry-run delegates to fw_btf.dry_run since the validation rules
-        # (vector-table SP/PC range, file-size minimum) and the packet-builder
-        # CRC self-checks differ from KDH. KDH path below is unchanged.
+        # Both protocols delegate to their driver's dry_run (packet-build
+        # validation + CRC self-checks; no serial). The KDH path used to
+        # hand-roll that validation/packet-build loop inline here — the same
+        # work fw.dry_run already does and TestDryRun already covers — so it
+        # had no shared source of truth. It now routes through
+        # fw.dry_run(log_cb=…) exactly as the BTF branch already routed through
+        # fw_btf.dry_run, selected via the frame's _driver_for dispatch.
         frame = self.frame
         radio = frame._get_selected_radio()
-        if (radio or {}).get("protocol") == "btf":
-            try:
-                self.log_msg(t("log.dryrun_header"))
-                self.log_msg("")
-                fw_btf.dry_run(firmware_path, log_cb=self.log_msg)
-                self.set_progress(100)
-                frame._terminal_state = "dryrun_complete"
-            except Exception as e:
-                self.log_msg(t("log.error_prefix").format(message=e))
-                frame._terminal_state = "failed"
-            finally:
-                frame._busy = False
-                self.set_buttons(True)
-            return
-
+        driver = frame._driver_for(radio)
         try:
-            import os
-            import hashlib
-            import math
-
             self.log_msg(t("log.dryrun_header"))
             self.log_msg("")
-
-            fw_size = os.path.getsize(firmware_path)
-            if fw_size > fw.MAX_FIRMWARE_BYTES:
-                self.log_msg(t("log.fail_too_large").format(
-                    size=fw_size, max=fw.MAX_FIRMWARE_BYTES))
-                frame._terminal_state = "failed"
-                return
-            with open(firmware_path, "rb") as f:
-                firmware = f.read()
-
-            fw_size = len(firmware)
-            total_chunks = math.ceil(fw_size / 1024)
-
-            if fw_size < fw.MIN_FIRMWARE_BYTES:
-                self.log_msg(t("log.fail_too_small").format(size=fw_size))
-                frame._terminal_state = "failed"
-                return
-            if total_chunks > fw.MAX_CHUNKS:
-                self.log_msg(t("log.fail_too_many_chunks").format(
-                    chunks=total_chunks, max=fw.MAX_CHUNKS))
-                frame._terminal_state = "failed"
-                return
-
-            sha256 = hashlib.sha256(firmware).hexdigest()
-            self.log_msg(t("log.firmware_path").format(path=firmware_path))
-            self.log_msg(t("log.size_chunks").format(size=fw_size, chunks=total_chunks))
-            self.log_msg(t("log.sha256").format(hash=sha256))
-            self.log_msg("")
-
-            sp = int.from_bytes(firmware[0:4], "little")
-            reset = int.from_bytes(firmware[4:8], "little")
-            ok_sp = 0x20000000 <= sp <= 0x20100000
-            ok_reset = 0x08000000 <= reset <= 0x08100000
-            valid_lbl = t("log.validity_valid")
-            invalid_lbl = t("log.validity_invalid")
-            self.log_msg(t("log.vector_table_check"))
-            self.log_msg(t("log.stack_pointer").format(
-                value=sp, validity=valid_lbl if ok_sp else invalid_lbl))
-            self.log_msg(t("log.reset_handler").format(
-                value=reset, validity=valid_lbl if ok_reset else invalid_lbl))
-            if not ok_sp or not ok_reset:
-                self.log_msg("")
-                self.log_msg(t("log.invalid_vector"))
-                frame._terminal_state = "failed"
-                return
-
-            self.log_msg("")
-            self.log_msg(t("log.building_packets"))
-            self.set_progress(10)
-
-            for i in range(total_chunks):
-                chunk = firmware[i * 1024:(i + 1) * 1024]
-                p = fw.build_packet(fw.CMD_UPDATE, i & 0xFF, chunk)
-                payload = p[1:-3]
-                pkt_crc = (p[-3] << 8) | p[-2]
-                if fw.crc16_ccitt(payload) != pkt_crc:
-                    self.log_msg(t("log.crc_fail_chunk").format(chunk=i))
-                    frame._terminal_state = "failed"
-                    return
-                self.set_progress(10 + (i + 1) / total_chunks * 90)
-
-            self.log_msg(t("log.packets_built").format(count=total_chunks + 3))
-            self.log_msg("")
-            self.log_msg(t("log.dryrun_passed"))
+            # KDH dry_run returns False on a validation failure; BTF dry_run
+            # raises (caught below). Either signal means the dry run failed.
+            ok = driver.dry_run(firmware_path, log_cb=self.log_msg)
             self.set_progress(100)
-            frame._terminal_state = "dryrun_complete"
-
+            frame._terminal_state = (
+                "dryrun_complete" if ok is not False else "failed")
         except Exception as e:
             self.log_msg(t("log.error_prefix").format(message=e))
             frame._terminal_state = "failed"
@@ -737,55 +646,40 @@ class FlashController:
     def diag_thread(self, port):
         frame = self.frame
         try:
-            import time
-
             self.log_msg(t("log.diag_running").format(port=port))
             self.log_msg("")
 
-            with serial.Serial(
-                port=port, baudrate=115200, bytesize=8,
-                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                timeout=1.0
-            ) as ser:
-                ser.dtr = True
-                ser.rts = True
-                time.sleep(0.1)
+            # Converged onto the driver's diagnostic_probe: opening the port,
+            # sending the protocol-appropriate handshake/probe and reading the
+            # reply was hand-rolled as serial.Serial inline here, so the
+            # diagnostics path had no headless coverage. The probe is dispatched
+            # through _driver_for so a BTF radio (RT-950 Pro) still gets its
+            # CMD_PROBE rather than the KDH handshake; the driver returns the
+            # raw exchange and the GUI formats the i18n log lines below.
+            driver = frame._driver_for(frame._get_selected_radio())
+            info = driver.diagnostic_probe(port)
 
-                self.log_msg(t("log.diag_serial_info").format(
-                    baud=ser.baudrate, dtr=ser.dtr, rts=ser.rts))
-                self.log_msg(t("log.diag_modem_lines").format(
-                    cts=ser.cts, dsr=ser.dsr))
+            self.log_msg(t("log.diag_serial_info").format(
+                baud=info["baudrate"], dtr=info["dtr"], rts=info["rts"]))
+            self.log_msg(t("log.diag_modem_lines").format(
+                cts=info["cts"], dsr=info["dsr"]))
+            self.log_msg("")
+
+            self.log_msg(t("log.diag_sending"))
+            self.log_msg(t("log.diag_tx").format(hex=info["tx_hex"]))
+            self.set_progress(50)
+            if info["responding"]:
+                self.log_msg(t("log.diag_rx").format(
+                    count=info["rx_count"], hex=info["rx_hex"]))
                 self.log_msg("")
-
-                self.log_msg(t("log.diag_sending"))
-                # Build the probe for the selected radio's protocol. A BTF
-                # radio (RT-950 Pro) answers a different handshake than the KDH
-                # bootloader, so sending the KDH packet would report "no
-                # response" even for a healthy BTF radio.
-                if (frame._get_selected_radio() or {}).get("protocol") == "btf":
-                    packet = fw_btf.build_packet(fw_btf.CMD_PROBE)
-                else:
-                    packet = fw.build_packet(fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
-                self.log_msg(t("log.diag_tx").format(hex=packet.hex()))
-                ser.reset_input_buffer()
-                ser.write(packet)
-                ser.flush()
-
-                self.set_progress(50)
-                time.sleep(1.0)
-                avail = ser.in_waiting
-                if avail:
-                    data = ser.read(min(avail, 128))
-                    self.log_msg(t("log.diag_rx").format(count=avail, hex=data.hex()))
-                    self.log_msg("")
-                    self.log_msg(t("log.diag_responding"))
-                    frame._terminal_state = "diag_complete"
-                else:
-                    self.log_msg(t("log.diag_no_rx"))
-                    self.log_msg("")
-                    self.log_msg(t("log.diag_no_response"))
-                    self.log_msg(t("log.diag_check"))
-                    frame._terminal_state = "failed"
+                self.log_msg(t("log.diag_responding"))
+                frame._terminal_state = "diag_complete"
+            else:
+                self.log_msg(t("log.diag_no_rx"))
+                self.log_msg("")
+                self.log_msg(t("log.diag_no_response"))
+                self.log_msg(t("log.diag_check"))
+                frame._terminal_state = "failed"
 
             self.set_progress(100)
 

--- a/gui_flash.py
+++ b/gui_flash.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""
+Serial operation workers: the flash / dry-run / diagnostics controller.
+
+This is the *controller* half of the Flash column's runtime — the change's
+namesake and highest-risk slice, because it is where background threads, live
+serial ports, and live widgets all meet. It owns:
+
+  * **The flash worker** — ``on_flash`` (validation / same-or-older-version
+    guard / single-vs-batch confirmation / ``_busy`` interlock) and the three
+    background workers behind it: ``flash_thread`` (single KDH),
+    ``flash_thread_btf`` (single RT-950 Pro), and ``batch_flash_thread``
+    (sequential multi-port with the Continue/Stop failure prompt in
+    ``prompt_continue_batch``).
+  * **Dry-run + diagnostics** — ``on_dry_run`` / ``dryrun_thread`` (packet-build
+    validation, no serial) and ``on_diag`` / ``diag_thread`` (a single
+    protocol-appropriate handshake probe over the wire).
+  * **Post-flash prompts** — ``offer_test_report`` (with per radio+version nag
+    suppression) and ``offer_firmware_cleanup``.
+  * **Worker plumbing** — ``log_msg`` / ``set_progress`` / ``set_buttons``, the
+    ``wx.CallAfter`` marshalling helpers every worker (here and in
+    DownloadController) routes log / progress / button-state writes through.
+
+``FlashController`` collaborates with the owning frame for everything only the
+frame can provide: the ``flash_btn`` / ``dryrun_btn`` / ``diag_btn`` / ``log`` /
+``progress`` / ``file_path`` widgets (built by gui_columns), the ``_busy`` /
+``_busy_state`` / ``_terminal_state`` / ``_closing`` flags it shares with the
+download worker, the selection model (``_get_selected_radio`` / ``_driver_for`` /
+``_get_firmware_url_and_version`` / ``_selected_handset_indices`` /
+``_handset_ports``), the handset-row updates (``_set_handset_status`` /
+``_set_handset_progress`` — HandsetController delegators), the serial-error
+helpers (``_is_permission_denied`` / ``_log_dialout_hint`` — shared with
+HandsetController's probe, so they stay frame-level), and the hint / workflow
+feedback (``_set_hint`` / ``_compute_hint_state`` / ``_update_radio_info`` /
+``_update_workflow_gating``).
+
+The frame keeps thin same-named delegators (``on_flash`` / ``on_dry_run`` /
+``on_diag`` bound by gui_columns, and ``log_msg`` / ``set_progress`` /
+``set_buttons`` called by DownloadController and the frame) so every existing
+call site keeps calling the same names, exactly as HandsetController's and
+DownloadController's delegators do. Every worker→widget update is marshalled onto
+the GUI thread with ``wx.CallAfter``; no worker touches a widget directly.
+
+``STATUS_*`` are the handset-list status i18n keys, imported from gui_handset so
+the batch/single workers and the controller that renders the cells share one
+definition.
+"""
+
+import os
+import threading
+
+try:
+    import wx
+except ImportError:
+    wx = None
+
+try:
+    import serial
+except ImportError:
+    serial = None
+
+import flash_firmware as fw
+import flash_btf as fw_btf
+import firmware_manifest as fm
+import firmware_version as fv
+from i18n import t
+from gui_dialogs import show_test_report_dialog
+from gui_handset import (
+    STATUS_FLASHING, STATUS_DONE, STATUS_FAILED, STATUS_SKIPPED,
+)
+
+
+class FlashController:
+    """Owns the flash / dry-run / diagnostics workers and their plumbing."""
+
+    def __init__(self, frame):
+        self.frame = frame
+
+    # ------------------------------------------------------------------
+    # Worker plumbing — every worker→widget write goes through these so it
+    # is marshalled onto the GUI thread via wx.CallAfter.
+    # ------------------------------------------------------------------
+
+    def log_msg(self, msg):
+        frame = self.frame
+        wx.CallAfter(frame.log.AppendText, msg + "\n")
+
+    def set_progress(self, pct):
+        frame = self.frame
+        wx.CallAfter(frame.progress.SetValue, int(pct))
+
+    def set_buttons(self, enabled):
+        frame = self.frame
+        wx.CallAfter(frame.flash_btn.Enable, enabled)
+        wx.CallAfter(frame.dryrun_btn.Enable, enabled)
+        wx.CallAfter(frame.diag_btn.Enable, enabled)
+        wx.CallAfter(frame.download_btn.Enable, enabled)
+        wx.CallAfter(frame.refresh_btn.Enable, enabled)
+        wx.CallAfter(frame.select_all_btn.Enable, enabled)
+        wx.CallAfter(frame.select_none_btn.Enable, enabled)
+        # Also lock the firmware inputs so a radio switch, path edit, or
+        # Browse can't fire mid-operation (which would let a second worker
+        # thread start on the same serial port). Re-enabled by the gating
+        # pass below on completion.
+        for w in ("radio_combo", "file_path", "browse_btn"):
+            widget = getattr(frame, w, None)
+            if widget is not None:
+                wx.CallAfter(widget.Enable, enabled)
+        if enabled:
+            wx.CallAfter(frame._update_radio_info)
+            # Recompute hint AFTER the thread has set _terminal_state
+            wx.CallAfter(lambda: frame._set_hint(frame._compute_hint_state()))
+            # Re-apply workflow gating so we don't enable buttons that
+            # should still be locked (e.g. Flash without a handset selected).
+            wx.CallAfter(frame._update_workflow_gating)
+
+    # ------------------------------------------------------------------
+    # Flash worker
+    # ------------------------------------------------------------------
+
+    def on_flash(self, event):
+        frame = self.frame
+        if frame._busy:
+            return
+        firmware_path = frame.file_path.GetValue()
+        if not firmware_path:
+            wx.MessageBox(t("dialog.error_select_firmware"),
+                          t("dialog.error_title"), wx.OK | wx.ICON_ERROR)
+            return
+
+        selected = frame._selected_handset_indices()
+        if not selected:
+            wx.MessageBox(t("dialog.error_no_handset_flash"),
+                          t("dialog.error_no_handset_title"),
+                          wx.OK | wx.ICON_ERROR)
+            return
+
+        radio = frame._get_selected_radio()
+        if radio:
+            keys = radio.get("bootloader_keys", t("fallback.bootloader_keys"))
+            radio_name = radio.get("name", t("fallback.radio_name"))
+            tested = radio.get("tested", False)
+        else:
+            keys = t("fallback.bootloader_keys")
+            radio_name = t("fallback.radio_name")
+            tested = False
+
+        warning = ""
+        if not tested:
+            warning = t("dialog.untested_warning").format(radio=radio_name)
+
+        # Same/older version checks (only meaningful for the single-handset path)
+        file_version = fv.extract_version_from_filename(os.path.basename(firmware_path))
+        if len(selected) == 1 and radio and file_version:
+            last = fm.get_last_flashed(radio["id"])
+            if last and last.get("version") == file_version:
+                same_dlg = wx.MessageDialog(frame,
+                    t("dialog.same_version_body").format(version=file_version),
+                    t("dialog.same_version_title"),
+                    wx.YES_NO | wx.ICON_QUESTION)
+                if same_dlg.ShowModal() != wx.ID_YES:
+                    same_dlg.Destroy()
+                    return
+                same_dlg.Destroy()
+            elif last and last.get("version") and fv.compare_versions(file_version, last["version"]) < 0:
+                older_dlg = wx.MessageDialog(frame,
+                    t("dialog.older_version_body").format(
+                        file_version=file_version, last_version=last['version']),
+                    t("dialog.older_version_title"),
+                    wx.YES_NO | wx.ICON_WARNING)
+                if older_dlg.ShowModal() != wx.ID_YES:
+                    older_dlg.Destroy()
+                    return
+                older_dlg.Destroy()
+
+        # Confirmation: single vs batch
+        if len(selected) == 1:
+            port_label = frame._handset_ports[selected[0]]["device"]
+            dlg = wx.MessageDialog(frame,
+                t("dialog.confirm_single").format(
+                    warning=warning, radio=radio_name,
+                    port=port_label, keys=keys),
+                t("dialog.confirm_title"), wx.YES_NO | wx.ICON_WARNING)
+        else:
+            ports_label = ", ".join(frame._handset_ports[i]["device"] for i in selected)
+            dlg = wx.MessageDialog(frame,
+                t("dialog.confirm_batch_body").format(
+                    warning=warning, count=len(selected),
+                    ports=ports_label, radio=radio_name, keys=keys),
+                t("dialog.confirm_batch_title"),
+                wx.YES_NO | wx.ICON_WARNING)
+
+        if dlg.ShowModal() != wx.ID_YES:
+            dlg.Destroy()
+            return
+        dlg.Destroy()
+
+        frame.log.Clear()
+        frame.progress.SetValue(0)
+        frame._busy = True
+        frame._busy_state = "flashing"
+        frame._terminal_state = None
+        self.set_buttons(False)
+        frame._set_hint("flashing")
+
+        if len(selected) == 1:
+            port = frame._handset_ports[selected[0]]["device"]
+            threading.Thread(target=self.flash_thread,
+                             args=(port, firmware_path, selected[0]),
+                             daemon=True).start()
+        else:
+            threading.Thread(target=self.batch_flash_thread,
+                             args=(list(selected), firmware_path),
+                             daemon=True).start()
+
+    def batch_flash_thread(self, selected_idxs, firmware_path):
+        """Sequentially flash the same firmware to every checked handset.
+
+        On per-port failure: prompt user to skip + continue or stop. Marks
+        each row's Status (Flashing… → Done/Failed/Skipped) and Progress.
+        """
+        frame = self.frame
+        radio = frame._get_selected_radio()
+        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
+
+        # Validate firmware once up front
+        driver = frame._driver_for(radio)
+        try:
+            with open(firmware_path, "rb") as f:
+                firmware_bytes = f.read()
+            driver.validate_firmware(firmware_bytes, firmware_path)
+        except Exception as e:
+            self.log_msg(t("log.error_prefix").format(message=e))
+            frame._terminal_state = "failed"
+            frame._busy = False
+            self.set_buttons(True)
+            return
+
+        total = len(selected_idxs)
+        succeeded = failed = skipped = 0
+        try:
+            for n, idx in enumerate(selected_idxs):
+                entry = frame._handset_ports[idx]
+                port = entry["device"]
+                wx.CallAfter(frame._set_handset_status, idx, STATUS_FLASHING)
+                wx.CallAfter(frame._set_handset_progress, idx, "0%")
+                self.log_msg(t("log.batch_start").format(
+                    n=n + 1, total=total, port=port, cable=entry['cable']))
+
+                def log_cb(msg, _idx=idx):
+                    self.log_msg(t("log.batch_per_port").format(
+                        port=frame._handset_ports[_idx]['device'], message=msg))
+
+                def progress_cb(pct, _idx=idx):
+                    pct_int = int(pct)
+                    wx.CallAfter(frame._set_handset_progress, _idx, f"{pct_int}%")
+
+                try:
+                    driver.flash_to_port(port, firmware_bytes,
+                                         log_cb=log_cb, progress_cb=progress_cb)
+                except Exception as e:
+                    failed += 1
+                    wx.CallAfter(frame._set_handset_status, idx, STATUS_FAILED)
+                    wx.CallAfter(frame._set_handset_progress, idx, "—")
+                    self.log_msg(t("log.batch_error").format(message=e))
+                    if frame._is_permission_denied(e):
+                        frame._log_dialout_hint(port)
+                        self.log_msg(t("log.batch_abort_permission"))
+                        for skip_idx in selected_idxs[n + 1:]:
+                            wx.CallAfter(frame._set_handset_status,
+                                         skip_idx, STATUS_SKIPPED)
+                            skipped += 1
+                        break
+                    if n < total - 1:
+                        if not self.prompt_continue_batch(port, str(e)):
+                            self.log_msg(t("log.batch_stopped"))
+                            for skip_idx in selected_idxs[n + 1:]:
+                                wx.CallAfter(frame._set_handset_status,
+                                             skip_idx, STATUS_SKIPPED)
+                                skipped += 1
+                            break
+                        self.log_msg(t("log.batch_continuing"))
+                else:
+                    succeeded += 1
+                    wx.CallAfter(frame._set_handset_status, idx, STATUS_DONE)
+                    wx.CallAfter(frame._set_handset_progress, idx, "100%")
+                self.set_progress(int((n + 1) * 100 / total))
+        finally:
+            self.log_msg(t("log.batch_summary").format(
+                ok=succeeded, failed=failed, skipped=skipped))
+            frame._terminal_state = "complete" if failed == 0 and skipped == 0 else "failed"
+            frame._busy = False
+            self.set_buttons(True)
+
+    def prompt_continue_batch(self, port, err):
+        """Block worker thread until user picks Continue or Stop on batch failure."""
+        frame = self.frame
+        ev = threading.Event()
+        choice = {"continue": False}
+
+        def show():
+            dlg = wx.MessageDialog(frame,
+                t("dialog.batch_failure_body").format(port=port, error=err),
+                t("dialog.batch_failure_title"),
+                wx.YES_NO | wx.ICON_WARNING)
+            choice["continue"] = (dlg.ShowModal() == wx.ID_YES)
+            dlg.Destroy()
+            ev.set()
+
+        wx.CallAfter(show)
+        ev.wait()
+        return choice["continue"]
+
+    def flash_thread(self, port, firmware_path, handset_idx=None):
+        frame = self.frame
+        radio = frame._get_selected_radio()
+        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
+
+        # BTF (RT-950 Pro) uses a different on-the-wire protocol than KDH;
+        # delegate to the BTF-specific path. The KDH inline flow below stays
+        # unchanged so existing translations and behavior are preserved.
+        if (radio or {}).get("protocol") == "btf":
+            return self.flash_thread_btf(port, firmware_path, handset_idx, radio)
+
+        # Derive once, up front, so both the success and failure paths pass the
+        # same identity to record_flash and to the test-report nag suppression.
+        radio_id = radio["id"] if radio else None
+        file_version = fv.extract_version_from_filename(
+            os.path.basename(firmware_path))
+
+        if handset_idx is not None:
+            wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_FLASHING)
+            wx.CallAfter(frame._set_handset_progress, handset_idx, "0%")
+
+        try:
+            import math
+            import time
+            import hashlib
+
+            fw_size = os.path.getsize(firmware_path)
+            if fw_size > fw.MAX_FIRMWARE_BYTES:
+                raise ValueError(t("log.file_too_large").format(size=fw_size))
+            with open(firmware_path, "rb") as f:
+                firmware = f.read()
+
+            fw.validate_firmware(firmware, firmware_path)
+            total_chunks = math.ceil(len(firmware) / 1024)
+            sha256 = hashlib.sha256(firmware).hexdigest()
+            self.log_msg(t("log.firmware_path").format(path=firmware_path))
+            self.log_msg(t("log.size_chunks").format(size=len(firmware), chunks=total_chunks))
+            self.log_msg(t("log.sha256").format(hash=sha256))
+            self.log_msg(t("log.port").format(port=port))
+            self.log_msg("")
+
+            with serial.Serial(
+                port=port, baudrate=115200, bytesize=8,
+                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
+                timeout=2.0, write_timeout=2.0
+            ) as ser:
+                ser.dtr = True
+                ser.rts = True
+                time.sleep(0.1)
+                ser.reset_input_buffer()
+                ser.reset_output_buffer()
+
+                self.log_msg(t("log.step_handshake"))
+                fw.send_command(ser, fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
+                self.log_msg(t("log.step_handshake_ok"))
+
+                self.log_msg(t("log.step_sending").format(chunks=total_chunks))
+                fw.send_command(ser, fw.CMD_UPDATE_DATA_PACKAGES, 0, bytes([total_chunks]))
+
+                for i in range(total_chunks):
+                    offset = i * 1024
+                    chunk = firmware[offset:offset + 1024]
+                    if len(chunk) < 1024:
+                        chunk = chunk + b'\x00' * (1024 - len(chunk))
+                    fw.send_command(ser, fw.CMD_UPDATE, i & 0xFF, chunk)
+                    pct = ((i + 1) / total_chunks) * 100
+                    self.set_progress(pct)
+                    if handset_idx is not None:
+                        wx.CallAfter(frame._set_handset_progress, handset_idx, f"{int(pct)}%")
+                    if (i + 1) % 10 == 0 or i == total_chunks - 1:
+                        self.log_msg(t("log.progress_line").format(
+                            pct=f"{pct:.0f}", done=i + 1, total=total_chunks))
+
+                self.log_msg(t("log.step_finalize"))
+                fw.send_command(ser, fw.CMD_UPDATE_END, 0)
+
+            self.log_msg(t("log.step_handshake_ok"))
+            self.log_msg("")
+            self.log_msg(t("log.flash_complete"))
+            self.log_msg(t("log.power_cycle"))
+            if handset_idx is not None:
+                wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_DONE)
+                wx.CallAfter(frame._set_handset_progress, handset_idx, "100%")
+
+            # Record flash version
+            if radio and file_version:
+                try:
+                    fm.record_flash(radio["id"], file_version, sha256)
+                    self.log_msg(t("log.recorded_flash").format(
+                        version=file_version, radio=radio_name))
+                except Exception:
+                    pass
+                # Compare against latest known
+                _, latest_ver = frame._get_firmware_url_and_version(radio)
+                if latest_ver and file_version:
+                    cmp = fv.compare_versions(file_version, latest_ver)
+                    if cmp == 0:
+                        self.log_msg(t("log.fw_is_latest").format(version=file_version))
+                    elif cmp < 0:
+                        self.log_msg(t("log.fw_newer_available").format(
+                            latest=latest_ver, current=file_version))
+
+            frame._terminal_state = "complete"
+            wx.CallAfter(self.offer_test_report, radio_name, firmware_path,
+                         True, "", radio_id, file_version)
+
+        except Exception as e:
+            error_msg = str(e)
+            self.log_msg(t("log.error_prefix").format(message=error_msg))
+            if frame._is_permission_denied(e):
+                frame._log_dialout_hint(port)
+            else:
+                self.log_msg(t("log.may_need_power_cycle"))
+            frame._terminal_state = "failed"
+            if handset_idx is not None:
+                wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_FAILED)
+                wx.CallAfter(frame._set_handset_progress, handset_idx, "—")
+            wx.CallAfter(self.offer_test_report, radio_name, firmware_path,
+                         False, error_msg, radio_id, file_version)
+        finally:
+            frame._busy = False
+            self.set_buttons(True)
+
+    def flash_thread_btf(self, port, firmware_path, handset_idx, radio):
+        # Single-port BTF flash. Mirrors flash_thread's structure (busy state,
+        # per-handset status, log messages, post-flash version recording, test
+        # report offer) but delegates the on-the-wire work to fw_btf.
+        frame = self.frame
+        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
+        # Derive once, up front, so both the success and failure paths pass the
+        # same identity to record_flash and to the test-report nag suppression.
+        radio_id = radio["id"] if radio else None
+        file_version = fv.extract_version_from_filename(
+            os.path.basename(firmware_path))
+        if handset_idx is not None:
+            wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_FLASHING)
+            wx.CallAfter(frame._set_handset_progress, handset_idx, "0%")
+
+        sha256 = ""
+        try:
+            import hashlib
+
+            fw_size = os.path.getsize(firmware_path)
+            if fw_size > fw_btf.MAX_FIRMWARE_BYTES:
+                raise ValueError(t("log.file_too_large").format(size=fw_size))
+            with open(firmware_path, "rb") as f:
+                firmware = f.read()
+
+            fw_btf.validate_firmware(firmware, firmware_path)
+            sha256 = hashlib.sha256(firmware).hexdigest()
+            self.log_msg(t("log.firmware_path").format(path=firmware_path))
+            self.log_msg(t("log.port").format(port=port))
+            self.log_msg("")
+
+            def log_cb(msg):
+                self.log_msg(msg)
+
+            def progress_cb(pct):
+                self.set_progress(pct)
+                if handset_idx is not None:
+                    wx.CallAfter(frame._set_handset_progress,
+                                 handset_idx, f"{int(pct)}%")
+
+            fw_btf.flash_to_port(port, firmware,
+                                 log_cb=log_cb, progress_cb=progress_cb)
+
+            self.log_msg("")
+            self.log_msg(t("log.flash_complete"))
+            if handset_idx is not None:
+                wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_DONE)
+                wx.CallAfter(frame._set_handset_progress, handset_idx, "100%")
+
+            if radio and file_version:
+                try:
+                    fm.record_flash(radio["id"], file_version, sha256)
+                    self.log_msg(t("log.recorded_flash").format(
+                        version=file_version, radio=radio_name))
+                except Exception:
+                    pass
+
+            frame._terminal_state = "complete"
+            wx.CallAfter(self.offer_test_report, radio_name, firmware_path,
+                         True, "", radio_id, file_version)
+
+        except Exception as e:
+            error_msg = str(e)
+            self.log_msg(t("log.error_prefix").format(message=error_msg))
+            if frame._is_permission_denied(e):
+                frame._log_dialout_hint(port)
+            else:
+                self.log_msg(t("log.may_need_power_cycle"))
+            frame._terminal_state = "failed"
+            if handset_idx is not None:
+                wx.CallAfter(frame._set_handset_status, handset_idx, STATUS_FAILED)
+                wx.CallAfter(frame._set_handset_progress, handset_idx, "—")
+            wx.CallAfter(self.offer_test_report, radio_name, firmware_path,
+                         False, error_msg, radio_id, file_version)
+        finally:
+            frame._busy = False
+            self.set_buttons(True)
+
+    def offer_test_report(self, radio_name, firmware_path, success, error_msg,
+                          radio_id=None, file_version=None):
+        # Nag suppression: once a report was submitted or explicitly skipped for
+        # this radio id + firmware version, don't offer again for that same
+        # combination (keyed the same grain record_flash uses). A plain Skip
+        # does not record anything, so it keeps prompting on future flashes.
+        frame = self.frame
+        if radio_id and fm.get_test_report_status(radio_id, file_version) in (
+                "submitted", "skipped"):
+            if success:
+                self.offer_firmware_cleanup(firmware_path)
+            return
+
+        log_content = frame.log.GetValue()
+        status = show_test_report_dialog(frame, radio_name, firmware_path,
+                                         success, error_msg, log_content)
+        if radio_id and status:
+            try:
+                fm.mark_test_report(radio_id, file_version, status)
+            except Exception:
+                # Recording the suppression state is best-effort: a corrupt or
+                # unwritable state file must not turn a successful flash into
+                # an error dialog. Worst case the user is asked again next time.
+                pass
+        if success:
+            self.offer_firmware_cleanup(firmware_path)
+
+    def offer_firmware_cleanup(self, firmware_path):
+        """Ask user if they want to delete downloaded firmware files."""
+        frame = self.frame
+        import firmware_download as dl
+
+        # Only offer cleanup if the firmware was downloaded by us
+        if not firmware_path or not firmware_path.startswith(dl.DOWNLOAD_DIR):
+            return
+
+        try:
+            download_dir = dl.DOWNLOAD_DIR
+            files = os.listdir(download_dir)
+            if not files:
+                return
+
+            total_size = sum(
+                os.path.getsize(os.path.join(download_dir, f))
+                for f in files
+                if os.path.isfile(os.path.join(download_dir, f))
+            )
+            size_mb = total_size / (1024 * 1024)
+
+            dlg = wx.MessageDialog(frame,
+                t("dialog.cleanup_body").format(
+                    size_mb=size_mb, path=download_dir),
+                t("dialog.cleanup_title"),
+                wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION)
+
+            if dlg.ShowModal() == wx.ID_YES:
+                import shutil
+                shutil.rmtree(download_dir, ignore_errors=True)
+                self.log_msg(t("log.cleanup_done"))
+                # The firmware we just flashed lived in that dir and is now
+                # gone. Clear the path field so the hint and workflow gating
+                # reflect that no firmware is loaded (otherwise the textbox
+                # shows a dead path and Flash stays enabled over a missing file).
+                if firmware_path.startswith(download_dir):
+                    frame.file_path.SetValue("")
+                    frame._terminal_state = None
+                    frame._update_workflow_gating()
+            dlg.Destroy()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Dry-run worker
+    # ------------------------------------------------------------------
+
+    def on_dry_run(self, event):
+        frame = self.frame
+        if frame._busy:
+            return
+        firmware_path = frame.file_path.GetValue()
+        if not firmware_path:
+            wx.MessageBox(t("dialog.error_select_firmware_first"),
+                          t("dialog.error_title"), wx.OK | wx.ICON_ERROR)
+            return
+
+        frame.log.Clear()
+        frame.progress.SetValue(0)
+        frame._busy = True
+        frame._busy_state = "dryrun"
+        frame._terminal_state = None
+        self.set_buttons(False)
+        frame._set_hint("dryrun")
+        threading.Thread(target=self.dryrun_thread, args=(firmware_path,), daemon=True).start()
+
+    def dryrun_thread(self, firmware_path):
+        # BTF dry-run delegates to fw_btf.dry_run since the validation rules
+        # (vector-table SP/PC range, file-size minimum) and the packet-builder
+        # CRC self-checks differ from KDH. KDH path below is unchanged.
+        frame = self.frame
+        radio = frame._get_selected_radio()
+        if (radio or {}).get("protocol") == "btf":
+            try:
+                self.log_msg(t("log.dryrun_header"))
+                self.log_msg("")
+                fw_btf.dry_run(firmware_path, log_cb=self.log_msg)
+                self.set_progress(100)
+                frame._terminal_state = "dryrun_complete"
+            except Exception as e:
+                self.log_msg(t("log.error_prefix").format(message=e))
+                frame._terminal_state = "failed"
+            finally:
+                frame._busy = False
+                self.set_buttons(True)
+            return
+
+        try:
+            import os
+            import hashlib
+            import math
+
+            self.log_msg(t("log.dryrun_header"))
+            self.log_msg("")
+
+            fw_size = os.path.getsize(firmware_path)
+            if fw_size > fw.MAX_FIRMWARE_BYTES:
+                self.log_msg(t("log.fail_too_large").format(
+                    size=fw_size, max=fw.MAX_FIRMWARE_BYTES))
+                frame._terminal_state = "failed"
+                return
+            with open(firmware_path, "rb") as f:
+                firmware = f.read()
+
+            fw_size = len(firmware)
+            total_chunks = math.ceil(fw_size / 1024)
+
+            if fw_size < fw.MIN_FIRMWARE_BYTES:
+                self.log_msg(t("log.fail_too_small").format(size=fw_size))
+                frame._terminal_state = "failed"
+                return
+            if total_chunks > fw.MAX_CHUNKS:
+                self.log_msg(t("log.fail_too_many_chunks").format(
+                    chunks=total_chunks, max=fw.MAX_CHUNKS))
+                frame._terminal_state = "failed"
+                return
+
+            sha256 = hashlib.sha256(firmware).hexdigest()
+            self.log_msg(t("log.firmware_path").format(path=firmware_path))
+            self.log_msg(t("log.size_chunks").format(size=fw_size, chunks=total_chunks))
+            self.log_msg(t("log.sha256").format(hash=sha256))
+            self.log_msg("")
+
+            sp = int.from_bytes(firmware[0:4], "little")
+            reset = int.from_bytes(firmware[4:8], "little")
+            ok_sp = 0x20000000 <= sp <= 0x20100000
+            ok_reset = 0x08000000 <= reset <= 0x08100000
+            valid_lbl = t("log.validity_valid")
+            invalid_lbl = t("log.validity_invalid")
+            self.log_msg(t("log.vector_table_check"))
+            self.log_msg(t("log.stack_pointer").format(
+                value=sp, validity=valid_lbl if ok_sp else invalid_lbl))
+            self.log_msg(t("log.reset_handler").format(
+                value=reset, validity=valid_lbl if ok_reset else invalid_lbl))
+            if not ok_sp or not ok_reset:
+                self.log_msg("")
+                self.log_msg(t("log.invalid_vector"))
+                frame._terminal_state = "failed"
+                return
+
+            self.log_msg("")
+            self.log_msg(t("log.building_packets"))
+            self.set_progress(10)
+
+            for i in range(total_chunks):
+                chunk = firmware[i * 1024:(i + 1) * 1024]
+                p = fw.build_packet(fw.CMD_UPDATE, i & 0xFF, chunk)
+                payload = p[1:-3]
+                pkt_crc = (p[-3] << 8) | p[-2]
+                if fw.crc16_ccitt(payload) != pkt_crc:
+                    self.log_msg(t("log.crc_fail_chunk").format(chunk=i))
+                    frame._terminal_state = "failed"
+                    return
+                self.set_progress(10 + (i + 1) / total_chunks * 90)
+
+            self.log_msg(t("log.packets_built").format(count=total_chunks + 3))
+            self.log_msg("")
+            self.log_msg(t("log.dryrun_passed"))
+            self.set_progress(100)
+            frame._terminal_state = "dryrun_complete"
+
+        except Exception as e:
+            self.log_msg(t("log.error_prefix").format(message=e))
+            frame._terminal_state = "failed"
+        finally:
+            frame._busy = False
+            self.set_buttons(True)
+
+    # ------------------------------------------------------------------
+    # Diagnostics worker
+    # ------------------------------------------------------------------
+
+    def on_diag(self, event):
+        frame = self.frame
+        if frame._busy:
+            return
+        # Diagnostics runs on a single port — use the first checked handset.
+        selected = frame._selected_handset_indices()
+        if not selected:
+            wx.MessageBox(t("dialog.error_no_handset_diag"),
+                          t("dialog.error_no_handset_title"),
+                          wx.OK | wx.ICON_ERROR)
+            return
+        port = frame._handset_ports[selected[0]]["device"]
+
+        frame.log.Clear()
+        frame.progress.SetValue(0)
+        frame._busy = True
+        frame._busy_state = "diagnostics"
+        frame._terminal_state = None
+        self.set_buttons(False)
+        frame._set_hint("diagnostics")
+        threading.Thread(target=self.diag_thread, args=(port,), daemon=True).start()
+
+    def diag_thread(self, port):
+        frame = self.frame
+        try:
+            import time
+
+            self.log_msg(t("log.diag_running").format(port=port))
+            self.log_msg("")
+
+            with serial.Serial(
+                port=port, baudrate=115200, bytesize=8,
+                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
+                timeout=1.0
+            ) as ser:
+                ser.dtr = True
+                ser.rts = True
+                time.sleep(0.1)
+
+                self.log_msg(t("log.diag_serial_info").format(
+                    baud=ser.baudrate, dtr=ser.dtr, rts=ser.rts))
+                self.log_msg(t("log.diag_modem_lines").format(
+                    cts=ser.cts, dsr=ser.dsr))
+                self.log_msg("")
+
+                self.log_msg(t("log.diag_sending"))
+                # Build the probe for the selected radio's protocol. A BTF
+                # radio (RT-950 Pro) answers a different handshake than the KDH
+                # bootloader, so sending the KDH packet would report "no
+                # response" even for a healthy BTF radio.
+                if (frame._get_selected_radio() or {}).get("protocol") == "btf":
+                    packet = fw_btf.build_packet(fw_btf.CMD_PROBE)
+                else:
+                    packet = fw.build_packet(fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
+                self.log_msg(t("log.diag_tx").format(hex=packet.hex()))
+                ser.reset_input_buffer()
+                ser.write(packet)
+                ser.flush()
+
+                self.set_progress(50)
+                time.sleep(1.0)
+                avail = ser.in_waiting
+                if avail:
+                    data = ser.read(min(avail, 128))
+                    self.log_msg(t("log.diag_rx").format(count=avail, hex=data.hex()))
+                    self.log_msg("")
+                    self.log_msg(t("log.diag_responding"))
+                    frame._terminal_state = "diag_complete"
+                else:
+                    self.log_msg(t("log.diag_no_rx"))
+                    self.log_msg("")
+                    self.log_msg(t("log.diag_no_response"))
+                    self.log_msg(t("log.diag_check"))
+                    frame._terminal_state = "failed"
+
+            self.set_progress(100)
+
+        except Exception as e:
+            self.log_msg(t("log.error_prefix").format(message=e))
+            if frame._is_permission_denied(e):
+                frame._log_dialout_hint(port)
+            frame._terminal_state = "failed"
+        finally:
+            frame._busy = False
+            self.set_buttons(True)

--- a/gui_main.py
+++ b/gui_main.py
@@ -16,14 +16,11 @@ import flash_firmware as fw
 import flash_btf as fw_btf
 import firmware_download as dl
 import firmware_manifest as fm
-import firmware_version as fv
 import i18n
 from i18n import t, t_radio_field, t_variant_field
-import serial
 
 from gui_dialogs import (
     show_about_dialog,
-    show_test_report_dialog,
 )
 from gui_themes import apply_theme, THEME_PALETTES, MOCHA_PALETTE
 from gui_themes import _walk as _theme_walk, _style_widget as _theme_style_widget
@@ -39,13 +36,8 @@ from gui_columns import (
 )
 from gui_hints import HintPresenter, format_variant_prompt
 from gui_download import DownloadController
-from gui_handset import (
-    HandsetController,
-    # Flash-worker status values (i18n keys) — comparisons use these symbolic
-    # constants; only the on-screen text runs through t(). The full status
-    # vocabulary lives in gui_handset alongside the controller that emits it.
-    STATUS_FLASHING, STATUS_DONE, STATUS_FAILED, STATUS_SKIPPED,
-)
+from gui_flash import FlashController
+from gui_handset import HandsetController
 
 VERSION = "26.07.0"
 
@@ -104,6 +96,12 @@ class FlasherFrame(wx.Frame):
         # DownloadController; the frame exposes thin delegators below and a
         # `manifest` property shim over the controller.
         self.download = DownloadController(self)
+        # Serial operation workers (flash / dry-run / diagnostics) plus their
+        # log/progress/button plumbing live in FlashController; the frame
+        # exposes thin delegators below (on_flash / on_dry_run / on_diag bound
+        # by gui_columns, log_msg / set_progress / set_buttons reused by the
+        # download worker).
+        self.flash = FlashController(self)
 
         # Window icon
         icon_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icon_128.png")
@@ -1185,425 +1183,42 @@ class FlasherFrame(wx.Frame):
     def on_browse(self, event):
         self.download.on_browse(event)
 
+    # ------------------------------------------------------------------
+    # Serial operation workers — behavior in FlashController (gui_flash).
+    # These thin wrappers keep the gui_columns button bindings (on_flash /
+    # on_dry_run / on_diag), the DownloadController plumbing calls (log_msg /
+    # set_progress / set_buttons) and the internal thread targets calling the
+    # same names while the logic lives in the controller.
+    # ------------------------------------------------------------------
+
     def log_msg(self, msg):
-        wx.CallAfter(self.log.AppendText, msg + "\n")
+        self.flash.log_msg(msg)
 
     def set_progress(self, pct):
-        wx.CallAfter(self.progress.SetValue, int(pct))
+        self.flash.set_progress(pct)
 
     def set_buttons(self, enabled):
-        wx.CallAfter(self.flash_btn.Enable, enabled)
-        wx.CallAfter(self.dryrun_btn.Enable, enabled)
-        wx.CallAfter(self.diag_btn.Enable, enabled)
-        wx.CallAfter(self.download_btn.Enable, enabled)
-        wx.CallAfter(self.refresh_btn.Enable, enabled)
-        wx.CallAfter(self.select_all_btn.Enable, enabled)
-        wx.CallAfter(self.select_none_btn.Enable, enabled)
-        # Also lock the firmware inputs so a radio switch, path edit, or
-        # Browse can't fire mid-operation (which would let a second worker
-        # thread start on the same serial port). Re-enabled by the gating
-        # pass below on completion.
-        for w in ("radio_combo", "file_path", "browse_btn"):
-            widget = getattr(self, w, None)
-            if widget is not None:
-                wx.CallAfter(widget.Enable, enabled)
-        if enabled:
-            wx.CallAfter(self._update_radio_info)
-            # Recompute hint AFTER the thread has set _terminal_state
-            wx.CallAfter(lambda: self._set_hint(self._compute_hint_state()))
-            # Re-apply workflow gating so we don't enable buttons that
-            # should still be locked (e.g. Flash without a handset selected).
-            wx.CallAfter(self._update_workflow_gating)
+        self.flash.set_buttons(enabled)
 
     def on_flash(self, event):
-        if self._busy:
-            return
-        firmware_path = self.file_path.GetValue()
-        if not firmware_path:
-            wx.MessageBox(t("dialog.error_select_firmware"),
-                          t("dialog.error_title"), wx.OK | wx.ICON_ERROR)
-            return
-
-        selected = self._selected_handset_indices()
-        if not selected:
-            wx.MessageBox(t("dialog.error_no_handset_flash"),
-                          t("dialog.error_no_handset_title"),
-                          wx.OK | wx.ICON_ERROR)
-            return
-
-        radio = self._get_selected_radio()
-        if radio:
-            keys = radio.get("bootloader_keys", t("fallback.bootloader_keys"))
-            radio_name = radio.get("name", t("fallback.radio_name"))
-            tested = radio.get("tested", False)
-        else:
-            keys = t("fallback.bootloader_keys")
-            radio_name = t("fallback.radio_name")
-            tested = False
-
-        warning = ""
-        if not tested:
-            warning = t("dialog.untested_warning").format(radio=radio_name)
-
-        # Same/older version checks (only meaningful for the single-handset path)
-        file_version = fv.extract_version_from_filename(os.path.basename(firmware_path))
-        if len(selected) == 1 and radio and file_version:
-            last = fm.get_last_flashed(radio["id"])
-            if last and last.get("version") == file_version:
-                same_dlg = wx.MessageDialog(self,
-                    t("dialog.same_version_body").format(version=file_version),
-                    t("dialog.same_version_title"),
-                    wx.YES_NO | wx.ICON_QUESTION)
-                if same_dlg.ShowModal() != wx.ID_YES:
-                    same_dlg.Destroy()
-                    return
-                same_dlg.Destroy()
-            elif last and last.get("version") and fv.compare_versions(file_version, last["version"]) < 0:
-                older_dlg = wx.MessageDialog(self,
-                    t("dialog.older_version_body").format(
-                        file_version=file_version, last_version=last['version']),
-                    t("dialog.older_version_title"),
-                    wx.YES_NO | wx.ICON_WARNING)
-                if older_dlg.ShowModal() != wx.ID_YES:
-                    older_dlg.Destroy()
-                    return
-                older_dlg.Destroy()
-
-        # Confirmation: single vs batch
-        if len(selected) == 1:
-            port_label = self._handset_ports[selected[0]]["device"]
-            dlg = wx.MessageDialog(self,
-                t("dialog.confirm_single").format(
-                    warning=warning, radio=radio_name,
-                    port=port_label, keys=keys),
-                t("dialog.confirm_title"), wx.YES_NO | wx.ICON_WARNING)
-        else:
-            ports_label = ", ".join(self._handset_ports[i]["device"] for i in selected)
-            dlg = wx.MessageDialog(self,
-                t("dialog.confirm_batch_body").format(
-                    warning=warning, count=len(selected),
-                    ports=ports_label, radio=radio_name, keys=keys),
-                t("dialog.confirm_batch_title"),
-                wx.YES_NO | wx.ICON_WARNING)
-
-        if dlg.ShowModal() != wx.ID_YES:
-            dlg.Destroy()
-            return
-        dlg.Destroy()
-
-        self.log.Clear()
-        self.progress.SetValue(0)
-        self._busy = True
-        self._busy_state = "flashing"
-        self._terminal_state = None
-        self.set_buttons(False)
-        self._set_hint("flashing")
-
-        if len(selected) == 1:
-            port = self._handset_ports[selected[0]]["device"]
-            threading.Thread(target=self._flash_thread,
-                             args=(port, firmware_path, selected[0]),
-                             daemon=True).start()
-        else:
-            threading.Thread(target=self._batch_flash_thread,
-                             args=(list(selected), firmware_path),
-                             daemon=True).start()
+        self.flash.on_flash(event)
 
     def _batch_flash_thread(self, selected_idxs, firmware_path):
-        """Sequentially flash the same firmware to every checked handset.
-
-        On per-port failure: prompt user to skip + continue or stop. Marks
-        each row's Status (Flashing… → Done/Failed/Skipped) and Progress.
-        """
-        radio = self._get_selected_radio()
-        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
-
-        # Validate firmware once up front
-        driver = self._driver_for(radio)
-        try:
-            with open(firmware_path, "rb") as f:
-                firmware_bytes = f.read()
-            driver.validate_firmware(firmware_bytes, firmware_path)
-        except Exception as e:
-            self.log_msg(t("log.error_prefix").format(message=e))
-            self._terminal_state = "failed"
-            self._busy = False
-            self.set_buttons(True)
-            return
-
-        total = len(selected_idxs)
-        succeeded = failed = skipped = 0
-        try:
-            for n, idx in enumerate(selected_idxs):
-                entry = self._handset_ports[idx]
-                port = entry["device"]
-                wx.CallAfter(self._set_handset_status, idx, STATUS_FLASHING)
-                wx.CallAfter(self._set_handset_progress, idx, "0%")
-                self.log_msg(t("log.batch_start").format(
-                    n=n + 1, total=total, port=port, cable=entry['cable']))
-
-                def log_cb(msg, _idx=idx):
-                    self.log_msg(t("log.batch_per_port").format(
-                        port=self._handset_ports[_idx]['device'], message=msg))
-
-                def progress_cb(pct, _idx=idx):
-                    pct_int = int(pct)
-                    wx.CallAfter(self._set_handset_progress, _idx, f"{pct_int}%")
-
-                try:
-                    driver.flash_to_port(port, firmware_bytes,
-                                         log_cb=log_cb, progress_cb=progress_cb)
-                except Exception as e:
-                    failed += 1
-                    wx.CallAfter(self._set_handset_status, idx, STATUS_FAILED)
-                    wx.CallAfter(self._set_handset_progress, idx, "—")
-                    self.log_msg(t("log.batch_error").format(message=e))
-                    if self._is_permission_denied(e):
-                        self._log_dialout_hint(port)
-                        self.log_msg(t("log.batch_abort_permission"))
-                        for skip_idx in selected_idxs[n + 1:]:
-                            wx.CallAfter(self._set_handset_status,
-                                         skip_idx, STATUS_SKIPPED)
-                            skipped += 1
-                        break
-                    if n < total - 1:
-                        if not self._prompt_continue_batch(port, str(e)):
-                            self.log_msg(t("log.batch_stopped"))
-                            for skip_idx in selected_idxs[n + 1:]:
-                                wx.CallAfter(self._set_handset_status,
-                                             skip_idx, STATUS_SKIPPED)
-                                skipped += 1
-                            break
-                        self.log_msg(t("log.batch_continuing"))
-                else:
-                    succeeded += 1
-                    wx.CallAfter(self._set_handset_status, idx, STATUS_DONE)
-                    wx.CallAfter(self._set_handset_progress, idx, "100%")
-                self.set_progress(int((n + 1) * 100 / total))
-        finally:
-            self.log_msg(t("log.batch_summary").format(
-                ok=succeeded, failed=failed, skipped=skipped))
-            self._terminal_state = "complete" if failed == 0 and skipped == 0 else "failed"
-            self._busy = False
-            self.set_buttons(True)
+        self.flash.batch_flash_thread(selected_idxs, firmware_path)
 
     def _prompt_continue_batch(self, port, err):
-        """Block worker thread until user picks Continue or Stop on batch failure."""
-        ev = threading.Event()
-        choice = {"continue": False}
-
-        def show():
-            dlg = wx.MessageDialog(self,
-                t("dialog.batch_failure_body").format(port=port, error=err),
-                t("dialog.batch_failure_title"),
-                wx.YES_NO | wx.ICON_WARNING)
-            choice["continue"] = (dlg.ShowModal() == wx.ID_YES)
-            dlg.Destroy()
-            ev.set()
-
-        wx.CallAfter(show)
-        ev.wait()
-        return choice["continue"]
+        return self.flash.prompt_continue_batch(port, err)
 
     def _flash_thread(self, port, firmware_path, handset_idx=None):
-        radio = self._get_selected_radio()
-        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
-
-        # BTF (RT-950 Pro) uses a different on-the-wire protocol than KDH;
-        # delegate to the BTF-specific path. The KDH inline flow below stays
-        # unchanged so existing translations and behavior are preserved.
-        if (radio or {}).get("protocol") == "btf":
-            return self._flash_thread_btf(port, firmware_path, handset_idx, radio)
-
-        # Derive once, up front, so both the success and failure paths pass the
-        # same identity to record_flash and to the test-report nag suppression.
-        radio_id = radio["id"] if radio else None
-        file_version = fv.extract_version_from_filename(
-            os.path.basename(firmware_path))
-
-        if handset_idx is not None:
-            wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FLASHING)
-            wx.CallAfter(self._set_handset_progress, handset_idx, "0%")
-
-        try:
-            import math
-            import time
-            import hashlib
-
-            fw_size = os.path.getsize(firmware_path)
-            if fw_size > fw.MAX_FIRMWARE_BYTES:
-                raise ValueError(t("log.file_too_large").format(size=fw_size))
-            with open(firmware_path, "rb") as f:
-                firmware = f.read()
-
-            fw.validate_firmware(firmware, firmware_path)
-            total_chunks = math.ceil(len(firmware) / 1024)
-            sha256 = hashlib.sha256(firmware).hexdigest()
-            self.log_msg(t("log.firmware_path").format(path=firmware_path))
-            self.log_msg(t("log.size_chunks").format(size=len(firmware), chunks=total_chunks))
-            self.log_msg(t("log.sha256").format(hash=sha256))
-            self.log_msg(t("log.port").format(port=port))
-            self.log_msg("")
-
-            with serial.Serial(
-                port=port, baudrate=115200, bytesize=8,
-                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                timeout=2.0, write_timeout=2.0
-            ) as ser:
-                ser.dtr = True
-                ser.rts = True
-                time.sleep(0.1)
-                ser.reset_input_buffer()
-                ser.reset_output_buffer()
-
-                self.log_msg(t("log.step_handshake"))
-                fw.send_command(ser, fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
-                self.log_msg(t("log.step_handshake_ok"))
-
-                self.log_msg(t("log.step_sending").format(chunks=total_chunks))
-                fw.send_command(ser, fw.CMD_UPDATE_DATA_PACKAGES, 0, bytes([total_chunks]))
-
-                for i in range(total_chunks):
-                    offset = i * 1024
-                    chunk = firmware[offset:offset + 1024]
-                    if len(chunk) < 1024:
-                        chunk = chunk + b'\x00' * (1024 - len(chunk))
-                    fw.send_command(ser, fw.CMD_UPDATE, i & 0xFF, chunk)
-                    pct = ((i + 1) / total_chunks) * 100
-                    self.set_progress(pct)
-                    if handset_idx is not None:
-                        wx.CallAfter(self._set_handset_progress, handset_idx, f"{int(pct)}%")
-                    if (i + 1) % 10 == 0 or i == total_chunks - 1:
-                        self.log_msg(t("log.progress_line").format(
-                            pct=f"{pct:.0f}", done=i + 1, total=total_chunks))
-
-                self.log_msg(t("log.step_finalize"))
-                fw.send_command(ser, fw.CMD_UPDATE_END, 0)
-
-            self.log_msg(t("log.step_handshake_ok"))
-            self.log_msg("")
-            self.log_msg(t("log.flash_complete"))
-            self.log_msg(t("log.power_cycle"))
-            if handset_idx is not None:
-                wx.CallAfter(self._set_handset_status, handset_idx, STATUS_DONE)
-                wx.CallAfter(self._set_handset_progress, handset_idx, "100%")
-
-            # Record flash version
-            if radio and file_version:
-                try:
-                    fm.record_flash(radio["id"], file_version, sha256)
-                    self.log_msg(t("log.recorded_flash").format(
-                        version=file_version, radio=radio_name))
-                except Exception:
-                    pass
-                # Compare against latest known
-                _, latest_ver = self._get_firmware_url_and_version(radio)
-                if latest_ver and file_version:
-                    cmp = fv.compare_versions(file_version, latest_ver)
-                    if cmp == 0:
-                        self.log_msg(t("log.fw_is_latest").format(version=file_version))
-                    elif cmp < 0:
-                        self.log_msg(t("log.fw_newer_available").format(
-                            latest=latest_ver, current=file_version))
-
-            self._terminal_state = "complete"
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
-                         True, "", radio_id, file_version)
-
-        except Exception as e:
-            error_msg = str(e)
-            self.log_msg(t("log.error_prefix").format(message=error_msg))
-            if self._is_permission_denied(e):
-                self._log_dialout_hint(port)
-            else:
-                self.log_msg(t("log.may_need_power_cycle"))
-            self._terminal_state = "failed"
-            if handset_idx is not None:
-                wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FAILED)
-                wx.CallAfter(self._set_handset_progress, handset_idx, "—")
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
-                         False, error_msg, radio_id, file_version)
-        finally:
-            self._busy = False
-            self.set_buttons(True)
+        self.flash.flash_thread(port, firmware_path, handset_idx)
 
     def _flash_thread_btf(self, port, firmware_path, handset_idx, radio):
-        # Single-port BTF flash. Mirrors _flash_thread's structure (busy state,
-        # per-handset status, log messages, post-flash version recording, test
-        # report offer) but delegates the on-the-wire work to fw_btf.
-        radio_name = radio["name"] if radio else t("fallback.radio_unknown")
-        # Derive once, up front, so both the success and failure paths pass the
-        # same identity to record_flash and to the test-report nag suppression.
-        radio_id = radio["id"] if radio else None
-        file_version = fv.extract_version_from_filename(
-            os.path.basename(firmware_path))
-        if handset_idx is not None:
-            wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FLASHING)
-            wx.CallAfter(self._set_handset_progress, handset_idx, "0%")
+        self.flash.flash_thread_btf(port, firmware_path, handset_idx, radio)
 
-        sha256 = ""
-        try:
-            import hashlib
-
-            fw_size = os.path.getsize(firmware_path)
-            if fw_size > fw_btf.MAX_FIRMWARE_BYTES:
-                raise ValueError(t("log.file_too_large").format(size=fw_size))
-            with open(firmware_path, "rb") as f:
-                firmware = f.read()
-
-            fw_btf.validate_firmware(firmware, firmware_path)
-            sha256 = hashlib.sha256(firmware).hexdigest()
-            self.log_msg(t("log.firmware_path").format(path=firmware_path))
-            self.log_msg(t("log.port").format(port=port))
-            self.log_msg("")
-
-            def log_cb(msg):
-                self.log_msg(msg)
-
-            def progress_cb(pct):
-                self.set_progress(pct)
-                if handset_idx is not None:
-                    wx.CallAfter(self._set_handset_progress,
-                                 handset_idx, f"{int(pct)}%")
-
-            fw_btf.flash_to_port(port, firmware,
-                                 log_cb=log_cb, progress_cb=progress_cb)
-
-            self.log_msg("")
-            self.log_msg(t("log.flash_complete"))
-            if handset_idx is not None:
-                wx.CallAfter(self._set_handset_status, handset_idx, STATUS_DONE)
-                wx.CallAfter(self._set_handset_progress, handset_idx, "100%")
-
-            if radio and file_version:
-                try:
-                    fm.record_flash(radio["id"], file_version, sha256)
-                    self.log_msg(t("log.recorded_flash").format(
-                        version=file_version, radio=radio_name))
-                except Exception:
-                    pass
-
-            self._terminal_state = "complete"
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
-                         True, "", radio_id, file_version)
-
-        except Exception as e:
-            error_msg = str(e)
-            self.log_msg(t("log.error_prefix").format(message=error_msg))
-            if self._is_permission_denied(e):
-                self._log_dialout_hint(port)
-            else:
-                self.log_msg(t("log.may_need_power_cycle"))
-            self._terminal_state = "failed"
-            if handset_idx is not None:
-                wx.CallAfter(self._set_handset_status, handset_idx, STATUS_FAILED)
-                wx.CallAfter(self._set_handset_progress, handset_idx, "—")
-            wx.CallAfter(self._offer_test_report, radio_name, firmware_path,
-                         False, error_msg, radio_id, file_version)
-        finally:
-            self._busy = False
-            self.set_buttons(True)
-
+    # _is_permission_denied and _log_dialout_hint stay on the frame: they are
+    # shared serial-error helpers HandsetController's probe thread also calls
+    # (frame._log_dialout_hint), so moving them would only add a reverse
+    # dependency for no benefit.
     def _is_permission_denied(self, exc):
         """True if the exception looks like a serial-port EACCES (Linux dialout)."""
         if isinstance(exc, PermissionError):
@@ -1622,275 +1237,23 @@ class FlasherFrame(wx.Frame):
 
     def _offer_test_report(self, radio_name, firmware_path, success, error_msg,
                            radio_id=None, file_version=None):
-        # Nag suppression: once a report was submitted or explicitly skipped for
-        # this radio id + firmware version, don't offer again for that same
-        # combination (keyed the same grain record_flash uses). A plain Skip
-        # does not record anything, so it keeps prompting on future flashes.
-        if radio_id and fm.get_test_report_status(radio_id, file_version) in (
-                "submitted", "skipped"):
-            if success:
-                self._offer_firmware_cleanup(firmware_path)
-            return
-
-        log_content = self.log.GetValue()
-        status = show_test_report_dialog(self, radio_name, firmware_path,
-                                         success, error_msg, log_content)
-        if radio_id and status:
-            try:
-                fm.mark_test_report(radio_id, file_version, status)
-            except Exception:
-                # Recording the suppression state is best-effort: a corrupt or
-                # unwritable state file must not turn a successful flash into
-                # an error dialog. Worst case the user is asked again next time.
-                pass
-        if success:
-            self._offer_firmware_cleanup(firmware_path)
+        self.flash.offer_test_report(radio_name, firmware_path, success,
+                                     error_msg, radio_id, file_version)
 
     def _offer_firmware_cleanup(self, firmware_path):
-        """Ask user if they want to delete downloaded firmware files."""
-        import firmware_download as dl
-
-        # Only offer cleanup if the firmware was downloaded by us
-        if not firmware_path or not firmware_path.startswith(dl.DOWNLOAD_DIR):
-            return
-
-        try:
-            download_dir = dl.DOWNLOAD_DIR
-            files = os.listdir(download_dir)
-            if not files:
-                return
-
-            total_size = sum(
-                os.path.getsize(os.path.join(download_dir, f))
-                for f in files
-                if os.path.isfile(os.path.join(download_dir, f))
-            )
-            size_mb = total_size / (1024 * 1024)
-
-            dlg = wx.MessageDialog(self,
-                t("dialog.cleanup_body").format(
-                    size_mb=size_mb, path=download_dir),
-                t("dialog.cleanup_title"),
-                wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION)
-
-            if dlg.ShowModal() == wx.ID_YES:
-                import shutil
-                shutil.rmtree(download_dir, ignore_errors=True)
-                self.log_msg(t("log.cleanup_done"))
-                # The firmware we just flashed lived in that dir and is now
-                # gone. Clear the path field so the hint and workflow gating
-                # reflect that no firmware is loaded (otherwise the textbox
-                # shows a dead path and Flash stays enabled over a missing file).
-                if firmware_path.startswith(download_dir):
-                    self.file_path.SetValue("")
-                    self._terminal_state = None
-                    self._update_workflow_gating()
-            dlg.Destroy()
-        except Exception:
-            pass
+        self.flash.offer_firmware_cleanup(firmware_path)
 
     def on_dry_run(self, event):
-        if self._busy:
-            return
-        firmware_path = self.file_path.GetValue()
-        if not firmware_path:
-            wx.MessageBox(t("dialog.error_select_firmware_first"),
-                          t("dialog.error_title"), wx.OK | wx.ICON_ERROR)
-            return
-
-        self.log.Clear()
-        self.progress.SetValue(0)
-        self._busy = True
-        self._busy_state = "dryrun"
-        self._terminal_state = None
-        self.set_buttons(False)
-        self._set_hint("dryrun")
-        threading.Thread(target=self._dryrun_thread, args=(firmware_path,), daemon=True).start()
+        self.flash.on_dry_run(event)
 
     def _dryrun_thread(self, firmware_path):
-        # BTF dry-run delegates to fw_btf.dry_run since the validation rules
-        # (vector-table SP/PC range, file-size minimum) and the packet-builder
-        # CRC self-checks differ from KDH. KDH path below is unchanged.
-        radio = self._get_selected_radio()
-        if (radio or {}).get("protocol") == "btf":
-            try:
-                self.log_msg(t("log.dryrun_header"))
-                self.log_msg("")
-                fw_btf.dry_run(firmware_path, log_cb=self.log_msg)
-                self.set_progress(100)
-                self._terminal_state = "dryrun_complete"
-            except Exception as e:
-                self.log_msg(t("log.error_prefix").format(message=e))
-                self._terminal_state = "failed"
-            finally:
-                self._busy = False
-                self.set_buttons(True)
-            return
-
-        try:
-            import os
-            import hashlib
-            import math
-
-            self.log_msg(t("log.dryrun_header"))
-            self.log_msg("")
-
-            fw_size = os.path.getsize(firmware_path)
-            if fw_size > fw.MAX_FIRMWARE_BYTES:
-                self.log_msg(t("log.fail_too_large").format(
-                    size=fw_size, max=fw.MAX_FIRMWARE_BYTES))
-                self._terminal_state = "failed"
-                return
-            with open(firmware_path, "rb") as f:
-                firmware = f.read()
-
-            fw_size = len(firmware)
-            total_chunks = math.ceil(fw_size / 1024)
-
-            if fw_size < fw.MIN_FIRMWARE_BYTES:
-                self.log_msg(t("log.fail_too_small").format(size=fw_size))
-                self._terminal_state = "failed"
-                return
-            if total_chunks > fw.MAX_CHUNKS:
-                self.log_msg(t("log.fail_too_many_chunks").format(
-                    chunks=total_chunks, max=fw.MAX_CHUNKS))
-                self._terminal_state = "failed"
-                return
-
-            sha256 = hashlib.sha256(firmware).hexdigest()
-            self.log_msg(t("log.firmware_path").format(path=firmware_path))
-            self.log_msg(t("log.size_chunks").format(size=fw_size, chunks=total_chunks))
-            self.log_msg(t("log.sha256").format(hash=sha256))
-            self.log_msg("")
-
-            sp = int.from_bytes(firmware[0:4], "little")
-            reset = int.from_bytes(firmware[4:8], "little")
-            ok_sp = 0x20000000 <= sp <= 0x20100000
-            ok_reset = 0x08000000 <= reset <= 0x08100000
-            valid_lbl = t("log.validity_valid")
-            invalid_lbl = t("log.validity_invalid")
-            self.log_msg(t("log.vector_table_check"))
-            self.log_msg(t("log.stack_pointer").format(
-                value=sp, validity=valid_lbl if ok_sp else invalid_lbl))
-            self.log_msg(t("log.reset_handler").format(
-                value=reset, validity=valid_lbl if ok_reset else invalid_lbl))
-            if not ok_sp or not ok_reset:
-                self.log_msg("")
-                self.log_msg(t("log.invalid_vector"))
-                self._terminal_state = "failed"
-                return
-
-            self.log_msg("")
-            self.log_msg(t("log.building_packets"))
-            self.set_progress(10)
-
-            for i in range(total_chunks):
-                chunk = firmware[i * 1024:(i + 1) * 1024]
-                p = fw.build_packet(fw.CMD_UPDATE, i & 0xFF, chunk)
-                payload = p[1:-3]
-                pkt_crc = (p[-3] << 8) | p[-2]
-                if fw.crc16_ccitt(payload) != pkt_crc:
-                    self.log_msg(t("log.crc_fail_chunk").format(chunk=i))
-                    self._terminal_state = "failed"
-                    return
-                self.set_progress(10 + (i + 1) / total_chunks * 90)
-
-            self.log_msg(t("log.packets_built").format(count=total_chunks + 3))
-            self.log_msg("")
-            self.log_msg(t("log.dryrun_passed"))
-            self.set_progress(100)
-            self._terminal_state = "dryrun_complete"
-
-        except Exception as e:
-            self.log_msg(t("log.error_prefix").format(message=e))
-            self._terminal_state = "failed"
-        finally:
-            self._busy = False
-            self.set_buttons(True)
+        self.flash.dryrun_thread(firmware_path)
 
     def on_diag(self, event):
-        if self._busy:
-            return
-        # Diagnostics runs on a single port — use the first checked handset.
-        selected = self._selected_handset_indices()
-        if not selected:
-            wx.MessageBox(t("dialog.error_no_handset_diag"),
-                          t("dialog.error_no_handset_title"),
-                          wx.OK | wx.ICON_ERROR)
-            return
-        port = self._handset_ports[selected[0]]["device"]
-
-        self.log.Clear()
-        self.progress.SetValue(0)
-        self._busy = True
-        self._busy_state = "diagnostics"
-        self._terminal_state = None
-        self.set_buttons(False)
-        self._set_hint("diagnostics")
-        threading.Thread(target=self._diag_thread, args=(port,), daemon=True).start()
+        self.flash.on_diag(event)
 
     def _diag_thread(self, port):
-        try:
-            import time
-
-            self.log_msg(t("log.diag_running").format(port=port))
-            self.log_msg("")
-
-            with serial.Serial(
-                port=port, baudrate=115200, bytesize=8,
-                parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                timeout=1.0
-            ) as ser:
-                ser.dtr = True
-                ser.rts = True
-                time.sleep(0.1)
-
-                self.log_msg(t("log.diag_serial_info").format(
-                    baud=ser.baudrate, dtr=ser.dtr, rts=ser.rts))
-                self.log_msg(t("log.diag_modem_lines").format(
-                    cts=ser.cts, dsr=ser.dsr))
-                self.log_msg("")
-
-                self.log_msg(t("log.diag_sending"))
-                # Build the probe for the selected radio's protocol. A BTF
-                # radio (RT-950 Pro) answers a different handshake than the KDH
-                # bootloader, so sending the KDH packet would report "no
-                # response" even for a healthy BTF radio.
-                if (self._get_selected_radio() or {}).get("protocol") == "btf":
-                    packet = fw_btf.build_packet(fw_btf.CMD_PROBE)
-                else:
-                    packet = fw.build_packet(fw.CMD_HANDSHAKE, 0, b"BOOTLOADER")
-                self.log_msg(t("log.diag_tx").format(hex=packet.hex()))
-                ser.reset_input_buffer()
-                ser.write(packet)
-                ser.flush()
-
-                self.set_progress(50)
-                time.sleep(1.0)
-                avail = ser.in_waiting
-                if avail:
-                    data = ser.read(min(avail, 128))
-                    self.log_msg(t("log.diag_rx").format(count=avail, hex=data.hex()))
-                    self.log_msg("")
-                    self.log_msg(t("log.diag_responding"))
-                    self._terminal_state = "diag_complete"
-                else:
-                    self.log_msg(t("log.diag_no_rx"))
-                    self.log_msg("")
-                    self.log_msg(t("log.diag_no_response"))
-                    self.log_msg(t("log.diag_check"))
-                    self._terminal_state = "failed"
-
-            self.set_progress(100)
-
-        except Exception as e:
-            self.log_msg(t("log.error_prefix").format(message=e))
-            if self._is_permission_denied(e):
-                self._log_dialout_hint(port)
-            self._terminal_state = "failed"
-        finally:
-            self._busy = False
-            self.set_buttons(True)
+        self.flash.diag_thread(port)
 
 
 def detect_os_theme():

--- a/mock_bootloader.py
+++ b/mock_bootloader.py
@@ -64,6 +64,14 @@ class MockSerial:
         self.dtr = False
         self.rts = False
         self.name = port
+        # Config + readable modem-status lines the diagnostics probe inspects.
+        # Stored/defaulted so a diagnostic_probe reads them like real pyserial
+        # (baudrate echoes the constructor kwarg; cts/dsr/cd/ri default low).
+        self.baudrate = kwargs.get("baudrate")
+        self.cts = False
+        self.dsr = False
+        self.cd = False
+        self.ri = False
 
     # -- context manager -------------------------------------------------- #
     def __enter__(self):

--- a/tests.py
+++ b/tests.py
@@ -1912,6 +1912,267 @@ class TestBatchFlashRouting(unittest.TestCase):
         self.assertEqual(eng_b.reassembled_firmware(), pad)
 
 
+class TestFlashControllerWrappers(unittest.TestCase):
+    """Headless, mock_bootloader-driven coverage of the extracted flash /
+    dry-run / diagnostics GUI workers (gui_flash.FlashController).
+
+    Before slice 3's driver convergence the single-flash KDH worker, the KDH
+    dry-run branch and the diagnostics worker hand-rolled ``serial.Serial`` +
+    ``send_command`` inline, so none of them had any headless coverage — they
+    could only be verified against a real radio. They now delegate to the
+    already-tested driver functions (``fw.flash_to_port`` / ``fw.dry_run`` /
+    ``driver.diagnostic_probe``), so the GUI wrapper is exercisable end-to-end
+    through ``mock_bootloader.patch_serial``, exactly like TestEndToEndFlashKDH
+    drives the driver directly. The controller touches widgets only through the
+    frame, so we bind it to a lightweight stub with fake widgets and a
+    synchronous ``wx.CallAfter``; the driver ``time.sleep`` pacing is stubbed
+    out so the suite stays fast."""
+
+    def setUp(self):
+        try:
+            import gui_flash
+            import mock_bootloader as mb
+            import flash_btf
+            import i18n
+        except ImportError:
+            self.skipTest("gui_flash / mock_bootloader not importable")
+        i18n.load_bundled_en()
+        self.gf = gui_flash
+        self.mb = mb
+        self.fw = fw
+        self.btf = flash_btf
+        import firmware_manifest as fm_mod
+        self.fm = fm_mod
+        self._orig_state_file = fm_mod.STATE_FILE
+        self._orig_state_dir = fm_mod.STATE_DIR
+        self._tmpdir = tempfile.mkdtemp()
+        fm_mod.STATE_FILE = os.path.join(self._tmpdir, "state.json")
+        fm_mod.STATE_DIR = self._tmpdir
+        # Route worker->widget writes synchronously and stub the report dialog.
+        self._saved_wx = gui_flash.wx
+        self._saved_dialog = gui_flash.show_test_report_dialog
+        gui_flash.wx = self._FakeWx
+        gui_flash.show_test_report_dialog = lambda *a, **k: None
+        # Stub the drivers' serial-pacing sleeps (MockSerial answers
+        # synchronously, so the 0.02s/chunk and 1.0s diag waits are pure
+        # latency the headless test shouldn't pay).
+        import time as _time
+        noslp = types.SimpleNamespace(sleep=lambda *a, **k: None, time=_time.time)
+        self._saved_fw_time = fw.time
+        self._saved_btf_time = flash_btf.time
+        fw.time = noslp
+        flash_btf.time = noslp
+
+    def tearDown(self):
+        self.gf.wx = self._saved_wx
+        self.gf.show_test_report_dialog = self._saved_dialog
+        self.fw.time = self._saved_fw_time
+        self.btf.time = self._saved_btf_time
+        self.fm.STATE_FILE = self._orig_state_file
+        self.fm.STATE_DIR = self._orig_state_dir
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    class _FakeWx:
+        @staticmethod
+        def CallAfter(func, *a, **k):
+            func(*a, **k)
+
+    class _FakeWidget:
+        def __init__(self, value=None):
+            self.value = value
+            self.enabled = None
+            self.label = None
+
+        def Enable(self, flag=True):
+            self.enabled = flag
+
+        def SetValue(self, v):
+            self.value = v
+
+        def GetValue(self):
+            return self.value
+
+        def Clear(self):
+            self.value = ""
+
+        def AppendText(self, s):
+            self.value = (self.value or "") + s
+
+        def SetLabel(self, s):
+            self.label = s
+
+    class _SilentEngine:
+        """A radio that swallows the probe and answers nothing (diag "no
+        response" path)."""
+        def try_extract(self, buf):
+            return ("packet", len(buf)) if buf else (None, 0)
+
+        def handle(self, packet):
+            return b""
+
+    def _frame(self, radio, **overrides):
+        f = types.SimpleNamespace()
+        f._closing = False
+        f._busy = True
+        f._busy_state = "flashing"
+        f._terminal_state = None
+        f.log = self._FakeWidget("")
+        f.progress = self._FakeWidget(0)
+        for name in ("flash_btn", "dryrun_btn", "diag_btn", "download_btn",
+                     "refresh_btn", "select_all_btn", "select_none_btn",
+                     "radio_combo", "browse_btn"):
+            setattr(f, name, self._FakeWidget())
+        f.file_path = self._FakeWidget("")
+        f.handset_status = []
+        f.handset_progress = []
+        f._set_handset_status = lambda idx, s: f.handset_status.append((idx, s))
+        f._set_handset_progress = lambda idx, s: f.handset_progress.append((idx, s))
+        f._get_selected_radio = lambda: radio
+        f._driver_for = lambda r: (
+            self.btf if (r or {}).get("protocol") == "btf" else self.fw)
+        f._get_firmware_url_and_version = lambda r: (None, None)
+        f._is_permission_denied = lambda e: False
+        f._log_dialout_hint = lambda port: None
+        f._set_hint = lambda s: None
+        f._compute_hint_state = lambda: "computed"
+        f._update_radio_info = lambda: None
+        f._update_workflow_gating = lambda: None
+        for k, v in overrides.items():
+            setattr(f, k, v)
+        return f
+
+    def _valid_kdh(self, nchunks=2):
+        header = struct.pack("<II", 0x200078E0, 0x08001185)
+        size = nchunks * 1024
+        return header + bytes((i * 7) & 0xFF for i in range(size - len(header)))
+
+    def _write(self, data, name):
+        path = os.path.join(self._tmpdir, name)
+        with open(path, "wb") as f:
+            f.write(data)
+        return path
+
+    # -- single-flash KDH wrapper (converged onto fw.flash_to_port) ------- #
+    def test_single_flash_kdh_delivers_bytes_and_completes(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio)
+        firmware = self._valid_kdh(3)
+        path = self._write(firmware, "ACME_V1.2_x.kdhx")
+        ctrl = self.gf.FlashController(frame)
+        engine = self.mb.KDHBootloader()
+        with self.mb.patch_serial(self.fw, engine=engine):
+            ctrl.flash_thread("/dev/mock", path, handset_idx=0)
+        self.assertTrue(engine.finished)
+        self.assertEqual(engine.reassembled_firmware(), firmware)
+        self.assertEqual(frame._terminal_state, "complete")
+        self.assertFalse(frame._busy)
+        self.assertEqual(frame.progress.value, 100)
+        self.assertIn((0, self.gf.STATUS_DONE), frame.handset_status)
+        # The flashed version was recorded (single source of truth for the
+        # same/older-version guard on the next flash).
+        self.assertEqual(self.fm.get_last_flashed("acme-x1")["version"], "1.2")
+        # Buttons are re-enabled by the finally-block re-gating pass.
+        self.assertTrue(frame.flash_btn.enabled)
+
+    def test_single_flash_kdh_failure_marks_failed(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio)
+        path = self._write(self._valid_kdh(2), "ACME_V1.2_x.kdhx")
+        ctrl = self.gf.FlashController(frame)
+        engine = self.mb.KDHBootloader(bad_handshake=True)
+        with self.mb.patch_serial(self.fw, engine=engine):
+            ctrl.flash_thread("/dev/mock", path, handset_idx=0)
+        self.assertFalse(engine.finished)
+        self.assertEqual(frame._terminal_state, "failed")
+        self.assertFalse(frame._busy)
+        self.assertIn((0, self.gf.STATUS_FAILED), frame.handset_status)
+        # A failed flash records nothing.
+        self.assertIsNone(self.fm.get_last_flashed("acme-x1"))
+
+    def _valid_btf(self, data_chunks=2):
+        off = self.btf.BTF_KEY_OFFSET + self.btf.BTF_KEY_SIZE
+        size = off + data_chunks * 1024
+        blob = bytearray(struct.pack("<II", 0x20001000, 0x08003185))
+        blob += bytes((i * 3) & 0xFF for i in range(size - 8))
+        sig = b"RT950PRO\x00"
+        blob[self.btf.BTF_MODEL_OFFSET:
+             self.btf.BTF_MODEL_OFFSET + len(sig)] = sig
+        return bytes(blob)
+
+    def test_single_flash_btf_delivers_bytes_and_completes(self):
+        # flash_thread dispatches a protocol="btf" radio to flash_thread_btf,
+        # which delegates the wire work to fw_btf.flash_to_port. This also
+        # exercises the same os-before-local-import fix in the BTF worker.
+        import contextlib
+        import io
+        radio = {"id": "rt950", "name": "RT-950 Pro", "protocol": "btf"}
+        frame = self._frame(radio)
+        path = self._write(self._valid_btf(2), "RT950_V2.0_x.BTF")
+        ctrl = self.gf.FlashController(frame)
+        engine = self.mb.BTFBootloader()
+        with contextlib.redirect_stdout(io.StringIO()):
+            with self.mb.patch_serial(self.btf, engine=engine):
+                ctrl.flash_thread("/dev/mock", path, handset_idx=0)
+        self.assertTrue(engine.finished)
+        self.assertEqual(frame._terminal_state, "complete")
+        self.assertFalse(frame._busy)
+        self.assertIn((0, self.gf.STATUS_DONE), frame.handset_status)
+
+    # -- dry-run wrapper (converged onto driver.dry_run) ----------------- #
+    def test_dryrun_kdh_passes(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio, _busy_state="dryrun")
+        path = self._write(self._valid_kdh(2), "fw.kdhx")
+        ctrl = self.gf.FlashController(frame)
+        ctrl.dryrun_thread(path)
+        self.assertEqual(frame._terminal_state, "dryrun_complete")
+        self.assertEqual(frame.progress.value, 100)
+        self.assertFalse(frame._busy)
+
+    def test_dryrun_kdh_invalid_fails(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio, _busy_state="dryrun")
+        path = self._write(b"\x00" * 100, "bad.kdhx")   # too small / bad vectors
+        ctrl = self.gf.FlashController(frame)
+        ctrl.dryrun_thread(path)
+        self.assertEqual(frame._terminal_state, "failed")
+        self.assertFalse(frame._busy)
+
+    # -- diagnostics wrapper (converged onto driver.diagnostic_probe) ---- #
+    def test_diagnostics_kdh_responding(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio, _busy_state="diagnostics")
+        ctrl = self.gf.FlashController(frame)
+        engine = self.mb.KDHBootloader()
+        with self.mb.patch_serial(self.fw, engine=engine):
+            ctrl.diag_thread("/dev/mock")
+        self.assertEqual(frame._terminal_state, "diag_complete")
+        self.assertEqual(frame.progress.value, 100)
+        self.assertFalse(frame._busy)
+
+    def test_diagnostics_btf_uses_btf_probe(self):
+        radio = {"id": "rt950", "name": "RT-950 Pro", "protocol": "btf"}
+        frame = self._frame(radio, _busy_state="diagnostics")
+        ctrl = self.gf.FlashController(frame)
+        engine = self.mb.BTFBootloader()
+        with self.mb.patch_serial(self.btf, engine=engine):
+            ctrl.diag_thread("/dev/mock")
+        # A BTF radio answers CMD_PROBE; the diag path dispatched through
+        # _driver_for must send the BTF probe, not the KDH handshake.
+        self.assertEqual(engine.commands_seen()[0], self.btf.CMD_PROBE)
+        self.assertEqual(frame._terminal_state, "diag_complete")
+
+    def test_diagnostics_no_response_fails(self):
+        radio = {"id": "acme-x1", "name": "Acme X1"}
+        frame = self._frame(radio, _busy_state="diagnostics")
+        ctrl = self.gf.FlashController(frame)
+        with self.mb.patch_serial(self.fw, engine=self._SilentEngine()):
+            ctrl.diag_thread("/dev/mock")
+        self.assertEqual(frame._terminal_state, "failed")
+        self.assertFalse(frame._busy)
+
+
 class TestWorkflowStateMachine(unittest.TestCase):
     """Pure workflow logic extracted from FlasherFrame (gui_workflow).
 

--- a/tests.py
+++ b/tests.py
@@ -1494,18 +1494,20 @@ class TestDialogReportTranslations(unittest.TestCase):
 
 
 class TestOfferTestReportSuppression(unittest.TestCase):
-    """FlasherFrame._offer_test_report must not show the dialog once a report
+    """FlashController.offer_test_report must not show the dialog once a report
     was submitted or explicitly skipped for a given radio+version, and must
-    persist the dialog's outcome otherwise. Bound onto a lightweight stub so it
-    runs headlessly (no wx.Frame / display), the pattern the variant-gating
-    tests use. The report dialog itself is monkeypatched out."""
+    persist the dialog's outcome otherwise. Bound onto a lightweight controller
+    stub (with a fake ``frame``) so it runs headlessly (no wx.Frame / display),
+    the pattern the variant-gating tests use. The report dialog itself is
+    monkeypatched out. Repointed from FlasherFrame to gui_flash when the flash
+    workers were extracted into FlashController (slice 3)."""
 
     def setUp(self):
         import importlib
         try:
-            self.gm = importlib.import_module("gui_main")
+            self.gf = importlib.import_module("gui_flash")
         except ImportError:
-            self.skipTest("gui_main not importable in this environment")
+            self.skipTest("gui_flash not importable in this environment")
         import firmware_manifest as fm_mod
         self.fm = fm_mod
         self._orig_state_file = fm_mod.STATE_FILE
@@ -1513,12 +1515,12 @@ class TestOfferTestReportSuppression(unittest.TestCase):
         self._tmpdir = tempfile.mkdtemp()
         fm_mod.STATE_FILE = os.path.join(self._tmpdir, "state.json")
         fm_mod.STATE_DIR = self._tmpdir
-        self._orig_dialog = self.gm.show_test_report_dialog
+        self._orig_dialog = self.gf.show_test_report_dialog
 
     def tearDown(self):
         self.fm.STATE_FILE = self._orig_state_file
         self.fm.STATE_DIR = self._orig_state_dir
-        self.gm.show_test_report_dialog = self._orig_dialog
+        self.gf.show_test_report_dialog = self._orig_dialog
         import shutil
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
@@ -1529,56 +1531,58 @@ class TestOfferTestReportSuppression(unittest.TestCase):
             calls.append(args)
             return dialog_return
 
-        self.gm.show_test_report_dialog = fake_dialog
+        self.gf.show_test_report_dialog = fake_dialog
+        frame = types.SimpleNamespace()
+        frame.log = types.SimpleNamespace(GetValue=lambda: "log text")
         stub = types.SimpleNamespace()
-        stub.log = types.SimpleNamespace(GetValue=lambda: "log text")
-        stub._offer_firmware_cleanup = lambda path: None
-        stub._offer_test_report = \
-            self.gm.FlasherFrame._offer_test_report.__get__(stub)
+        stub.frame = frame
+        stub.offer_firmware_cleanup = lambda path: None
+        stub.offer_test_report = \
+            self.gf.FlashController.offer_test_report.__get__(stub)
         return stub, calls
 
     def test_suppressed_after_submitted(self):
         self.fm.mark_test_report("radio-x", "1.0", "submitted")
         stub, calls = self._stub(None)
-        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
-                                radio_id="radio-x", file_version="1.0")
+        stub.offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
+                               radio_id="radio-x", file_version="1.0")
         self.assertEqual(calls, [], "dialog must not be shown when suppressed")
 
     def test_suppressed_after_skipped(self):
         self.fm.mark_test_report("radio-x", "1.0", "skipped")
         stub, calls = self._stub(None)
-        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", False, "boom",
-                                radio_id="radio-x", file_version="1.0")
+        stub.offer_test_report("Radio X", "/tmp/fw.kdhx", False, "boom",
+                               radio_id="radio-x", file_version="1.0")
         self.assertEqual(calls, [])
 
     def test_shown_when_not_recorded_and_plain_skip_does_not_persist(self):
         stub, calls = self._stub(None)  # dialog returns None => plain Skip
-        stub._offer_test_report("Radio Y", "/tmp/fw.kdhx", True, "",
-                                radio_id="radio-y", file_version="1.0")
+        stub.offer_test_report("Radio Y", "/tmp/fw.kdhx", True, "",
+                               radio_id="radio-y", file_version="1.0")
         self.assertEqual(len(calls), 1)
         # Plain Skip persists nothing, so a future flash still prompts.
         self.assertIsNone(self.fm.get_test_report_status("radio-y", "1.0"))
 
     def test_submit_outcome_persisted(self):
         stub, calls = self._stub("submitted")
-        stub._offer_test_report("Radio Z", "/tmp/fw.kdhx", True, "",
-                                radio_id="radio-z", file_version="2.0")
+        stub.offer_test_report("Radio Z", "/tmp/fw.kdhx", True, "",
+                               radio_id="radio-z", file_version="2.0")
         self.assertEqual(len(calls), 1)
         self.assertEqual(
             self.fm.get_test_report_status("radio-z", "2.0"), "submitted")
 
     def test_skip_with_checkbox_persisted(self):
         stub, calls = self._stub("skipped")
-        stub._offer_test_report("Radio W", "/tmp/fw.kdhx", False, "boom",
-                                radio_id="radio-w", file_version="3.0")
+        stub.offer_test_report("Radio W", "/tmp/fw.kdhx", False, "boom",
+                               radio_id="radio-w", file_version="3.0")
         self.assertEqual(
             self.fm.get_test_report_status("radio-w", "3.0"), "skipped")
 
     def test_new_version_prompts_again(self):
         self.fm.mark_test_report("radio-x", "1.0", "submitted")
         stub, calls = self._stub(None)
-        stub._offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
-                                radio_id="radio-x", file_version="2.0")
+        stub.offer_test_report("Radio X", "/tmp/fw.kdhx", True, "",
+                               radio_id="radio-x", file_version="2.0")
         self.assertEqual(len(calls), 1, "a new firmware version must prompt again")
 
 


### PR DESCRIPTION
## Summary

Final slice of [`openspec/changes/decompose-gui-main-workers`](https://github.com/FlintWave/flintwave-kdh-flasher/blob/master/openspec/changes/decompose-gui-main-workers/proposal.md), in two commits per its design:

1. **Move-only** (`af7cfac`): `FlashController` in `gui_flash.py` owns the flash/batch/dry-run/diag workers plus `log_msg`/`set_progress`/`set_buttons`; the frame keeps same-named delegators (zero churn at gui_columns bindings and sibling controllers). Workers moved verbatim; test-report/cleanup wiring preserved byte-for-byte. Suite stays 224.
2. **Driver convergence** (`23e9956`): single-flash KDH converges onto `fw.flash_to_port`, dry-run (KDH+BTF) onto `driver.dry_run`, diagnostics onto a new `diagnostic_probe(port)` in both drivers (the design-named `run_diagnostics` is a different multi-test CLI flow — reusing it would have changed behavior). These paths get their **first-ever headless mock-bootloader coverage** (+8 tests → **232**).

## 🐛 Real bug caught and fixed

The new coverage immediately surfaced an `UnboundLocalError` in both single-flash workers **on current master**: the test-report wiring (#35) derives `file_version` via `os.path.basename(...)` lines before the pre-existing function-local `import os`, making `os` function-local and unbound at first use — i.e., **single-handset flashing is broken on master right now** (batch is unaffected; released v26.07.0 is unaffected — verified against the tag). Fixed by dropping the redundant local import. This is exactly the blind spot the convergence commit exists to close.

## Behavior notes (hardware checklist gates these)

- Per-step flash log lines during a single KDH flash now come from the driver (matching what batch and BTF already show) instead of GUI i18n step keys; preamble logging, version recording, and post-flash prompts unchanged.
- Driver chunk pacing now applies to single KDH flash (as it always did for batch).

## `gui_main.py`: 1,826 → **1,188** lines (from ~2,305 pre-decomposition)

## Manual hardware checklist — DRAFT until all checked on a real radio

CI green is **not** sufficient to merge this slice.

- [ ] **Single KDH flash** — one checked handset: firmware preamble logged, driver flash steps, progress → 100%, row Flashing… → Done, version recorded.
- [ ] **Batch flash across 2 ports** — sequential, independent per-row status/progress, correct summary.
- [ ] **Batch induced failure** — Continue/Stop prompt; Stop marks remaining Skipped; summary counts correct.
- [ ] **BTF flash (RT-950 Pro)** — if hardware available.
- [ ] **Dry-run (KDH + BTF)** — validation output, progress → 100%; invalid file fails without touching a port.
- [ ] **Diagnostics (KDH + BTF)** — serial info + modem lines + TX hex; responding radio → RX hex; silent → "no response".
- [ ] **Dialout permission hint** — EACCES paths surface the hint (flash, batch abort, diagnostics).
- [ ] **Test-report + cleanup prompts** — offer once, suppress on repeat for same radio+version; cleanup only for downloaded files.
- [ ] **Button re-gating** — correct gated state after every operation, success or failure.

Implemented by an Opus agent from the OpenSpec scaffold; reviewed (including verifying the bug's origin in #35 against the v26.07.0 tag) and changelog added by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD