### PR TITLE
Fix UnboundLocalError breaking single-handset flash on master

### DIFF
--- a/gui_main.py
+++ b/gui_main.py
@@ -1328,7 +1328,6 @@ class FlasherFrame(wx.Frame):
         try:
             import math
             import time
-            import os
             import hashlib
 
             fw_size = os.path.getsize(firmware_path)
@@ -1444,7 +1443,7 @@ class FlasherFrame(wx.Frame):
 
         sha256 = ""
         try:
-            import os, hashlib
+            import hashlib
 
             fw_size = os.path.getsize(firmware_path)
             if fw_size > fw_btf.MAX_FIRMWARE_BYTES:


### PR DESCRIPTION
## Summary

#35's `file_version` derivation calls `os.path.basename(...)` at the top of both single-flash workers, while each worker kept an older function-local `import os` below — so `os` became function-local and unbound at first use. **Single-handset flashing (KDH and BTF) crashes immediately on master**; batch paths are unaffected, and released v26.07.0 predates the bug (verified against the tag).

Minimal fix: remove the redundant local imports; module-level `os` applies. Verified by an AST check that neither worker has a local `os` import remaining, plus the full suite (224 green).

Found by the new mock-bootloader coverage in the draft #38 (gui_flash extraction), which also carries this fix in its rewritten code — this hotfix exists so master isn't broken while #38 waits on its hardware checklist. I'll resolve the trivial overlap when #38 rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD