### PR TITLE
Reflowable layout: draggable, persisted splitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### UX / UI
 
+- **The window now reflows via draggable splitters.** The fixed 2:1 layout is replaced by a main sash between the three workflow columns and the instructions/log row, plus a second sash between Instructions and Log — drag space to whatever you're reading (the Instructions box was chronically crushed). Ratios persist across runs; asymmetric minimums keep the columns above the height where their controls would overlap while letting the bottom row compress gracefully; window resizes keep the ~60/40 feel and re-clamp.
 - **The hardware-variant walkthrough moved into the Firmware column**, directly under the radio picker, where it is fully visible at every window size. It previously rendered below the Instructions text, where the directions were scrolled out of view and the answer options were squeezed to zero height at the default window size (found in hardware + screenshot testing). The Instructions panel now shows a translated one-line pointer instead, no answer appears pre-selected before the user actually picks one (hidden GTK group anchor), and the question/steps text compresses before the answer buttons ever would.
 - **Stale translation caches can no longer hide new strings.** Downloaded catalogs cached by an older app version predate newly shipped keys; the loader now overlays the cache on the bundled catalog so every key this build knows about resolves to at least its bundled translation. Previously a stale cache left just the new strings (e.g. the variant walkthrough) in English while the rest of the UI was translated.
 

--- a/firmware_manifest.py
+++ b/firmware_manifest.py
@@ -303,3 +303,19 @@ def set_language(code):
     state = _load_state()
     state["language"] = code
     _save_state(state)
+
+
+def get_ui_sashes():
+    """Return persisted splitter sash ratios ({"main": float, "bottom":
+    float}) or {} if none stored / malformed."""
+    state = _load_state()
+    value = state.get("ui_sashes", {})
+    return value if isinstance(value, dict) else {}
+
+
+def set_ui_sashes(main_ratio, bottom_ratio):
+    """Persist the window's splitter sash ratios (0..1 of the pane span)."""
+    state = _load_state()
+    state["ui_sashes"] = {"main": round(float(main_ratio), 4),
+                          "bottom": round(float(bottom_ratio), 4)}
+    _save_state(state)

--- a/gui_main.py
+++ b/gui_main.py
@@ -118,7 +118,26 @@ class FlasherFrame(wx.Frame):
         self.title_bar = TitleBar(panel, self)
         root_sizer.Add(self.title_bar, 0, wx.EXPAND)
 
-        # ---- Top row: three columns separated by ">" arrows ----
+        # ---- Main splitter: three-column workflow above, instructions/log
+        # below. Replaces the old fixed 2:1 sizer stack so the user can drag
+        # vertical space to whichever area needs it — the Instructions box was
+        # chronically crushed at the fixed ratio. Sash positions persist
+        # across runs (see _apply_sash_ratios / _on_sash_changed).
+        self._main_split = wx.SplitterWindow(
+            panel, style=wx.SP_LIVE_UPDATE | wx.SP_NOBORDER)
+        # Base floor; the real (asymmetric) limits are enforced in
+        # _clamp_main_sash — the three columns need more room than the
+        # instructions/log row before their children start overlapping.
+        self._main_split.SetMinimumPaneSize(120)
+        # Window resizes distribute ~60/40, keeping the BalenaEtcher feel.
+        self._main_split.SetSashGravity(0.6)
+        self._main_split.Bind(wx.EVT_SPLITTER_SASH_POS_CHANGING,
+                              self._on_main_sash_changing)
+        # Gravity-driven window resizes bypass the CHANGING event and can
+        # push the top pane under its minimum; re-clamp after each resize.
+        self._main_split.Bind(wx.EVT_SIZE, self._on_main_split_size)
+
+        top_panel = wx.Panel(self._main_split)
         top_row = wx.BoxSizer(wx.HORIZONTAL)
 
         # Manifest state is owned by DownloadController (constructed above, so
@@ -133,16 +152,16 @@ class FlasherFrame(wx.Frame):
         # keeps Download disabled.
         self._variant_choice = {}
 
-        col_firmware = FirmwareColumn(panel, self)
-        col_handset = HandsetColumn(panel, self)
-        col_flash = FlashColumn(panel, self)
+        col_firmware = FirmwareColumn(top_panel, self)
+        col_handset = HandsetColumn(top_panel, self)
+        col_flash = FlashColumn(top_panel, self)
 
         # Bumped one size larger from previous 20pt to give more visual weight.
         arrow_font = wx.Font(28, wx.FONTFAMILY_DEFAULT,
                              wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
-        self.arrow1 = wx.StaticText(panel, label="›")  # firmware → handset
+        self.arrow1 = wx.StaticText(top_panel, label="›")  # firmware → handset
         self.arrow1.SetFont(arrow_font)
-        self.arrow2 = wx.StaticText(panel, label="›")  # handset → flash
+        self.arrow2 = wx.StaticText(top_panel, label="›")  # handset → flash
         self.arrow2.SetFont(arrow_font)
         # Pulse-state per arrow. Keyed by id(arrow) so we don't re-pulse
         # on every redundant gating refresh.
@@ -154,31 +173,21 @@ class FlasherFrame(wx.Frame):
         top_row.Add(col_handset, 1, wx.EXPAND | wx.ALL, 8)
         top_row.Add(self.arrow2, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 4)
         top_row.Add(col_flash, 1, wx.EXPAND | wx.ALL, 8)
+        top_panel.SetSizer(top_row)
 
-        # Top row gets 2/3 of vertical space (BalenaEtcher-style); middle (hints+log) gets 1/3.
-        root_sizer.Add(top_row, 2, wx.EXPAND)
-
-        # Thin (1px) divider between top columns and bottom hint/log row,
-        # centered and ~80% of the window width.
-        divider_row = wx.BoxSizer(wx.HORIZONTAL)
-        self._divider1 = wx.StaticLine(panel, style=wx.LI_HORIZONTAL,
-                                       size=(-1, 1))
-        self._divider1.SetMinSize(wx.Size(-1, 1))
-        divider_row.AddStretchSpacer(1)
-        divider_row.Add(self._divider1, 8, wx.EXPAND)
-        divider_row.AddStretchSpacer(1)
-        # Generous breathing room above and below the divider so the columns
-        # don't feel cramped against it.
-        root_sizer.Add(divider_row, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 16)
-
-        # ---- Middle row: instructions panel + log, each with a static label ----
-        middle_row = wx.BoxSizer(wx.HORIZONTAL)
+        # ---- Bottom half: instructions | log behind their own draggable
+        # sash (the main splitter's sash replaces the old decorative
+        # divider line).
+        self._bottom_split = wx.SplitterWindow(
+            self._main_split, style=wx.SP_LIVE_UPDATE | wx.SP_NOBORDER)
+        self._bottom_split.SetMinimumPaneSize(220)
+        self._bottom_split.SetSashGravity(0.5)
 
         # Instructions panel (left half). Use a read-only wx.TextCtrl with
         # rich-text styling for the body; native multi-line TextCtrl gives us
         # word-wrap + a v-scrollbar for free, which the previous
         # StaticText-in-ScrolledPanel approach couldn't reliably deliver.
-        self._instructions_outer = wx.Panel(panel)
+        self._instructions_outer = wx.Panel(self._bottom_split)
         self._instructions_outer.SetMinSize(wx.Size(1, -1))
         outer_sizer = wx.BoxSizer(wx.VERTICAL)
         instructions_label = self._column_heading(self._instructions_outer,
@@ -210,7 +219,7 @@ class FlasherFrame(wx.Frame):
         self._instructions_outer.SetSizer(outer_sizer)
 
         # Log panel (right half) — heading + textarea
-        self.log_panel = wx.Panel(panel)
+        self.log_panel = wx.Panel(self._bottom_split)
         self.log_panel.SetMinSize(wx.Size(200, -1))
         log_sizer = wx.BoxSizer(wx.VERTICAL)
         log_label = self._column_heading(self.log_panel, "column.log")
@@ -226,10 +235,17 @@ class FlasherFrame(wx.Frame):
         log_sizer.Add(self.log, 1, wx.EXPAND | wx.ALL, 10)
         self.log_panel.SetSizer(log_sizer)
 
-        middle_row.Add(self._instructions_outer, 1, wx.EXPAND | wx.LEFT | wx.BOTTOM, 8)
-        middle_row.AddSpacer(32)  # generous breathing room between Instructions and Log
-        middle_row.Add(self.log_panel, 1, wx.EXPAND | wx.RIGHT | wx.BOTTOM, 8)
-        root_sizer.Add(middle_row, 1, wx.EXPAND)
+        self._bottom_split.SplitVertically(self._instructions_outer,
+                                           self.log_panel)
+        self._main_split.SplitHorizontally(top_panel, self._bottom_split)
+        root_sizer.Add(self._main_split, 1, wx.EXPAND)
+
+        # Apply saved (or default) sash ratios once the window has real
+        # geometry, and persist any drag the user makes.
+        wx.CallAfter(self._apply_sash_ratios)
+        for splitter in (self._main_split, self._bottom_split):
+            splitter.Bind(wx.EVT_SPLITTER_SASH_POS_CHANGED,
+                          self._on_sash_changed)
 
         # ---- Bottom status bar: borderless text/icon links, darker background ----
         self.status_bar_panel = StatusBar(panel, self)
@@ -739,6 +755,73 @@ class FlasherFrame(wx.Frame):
     # ------------------------------------------------------------------
     # Font controls (theme has a Mocha/Latte toggle in the status bar)
     # ------------------------------------------------------------------
+
+    # Asymmetric limits for the main (vertical) split: below ~300px the
+    # three workflow columns' children start overlapping (the variant
+    # walkthrough compresses its text first, but buttons/rows have fixed
+    # heights); the instructions/log row degrades gracefully down to ~140px
+    # since both sides are scrollable text.
+    _MAIN_TOP_MIN = 300
+    _MAIN_BOTTOM_MIN = 140
+
+    def _clamp_main_sash(self, position):
+        height = max(1, self._main_split.GetClientSize().height)
+        upper = max(self._MAIN_TOP_MIN, height - self._MAIN_BOTTOM_MIN)
+        return max(self._MAIN_TOP_MIN, min(int(position), upper))
+
+    def _on_main_sash_changing(self, event):
+        event.SetSashPosition(self._clamp_main_sash(event.GetSashPosition()))
+
+    def _on_main_split_size(self, event):
+        event.Skip()
+        if not self._main_split.IsSplit():
+            return
+
+        def _reclamp():
+            clamped = self._clamp_main_sash(
+                self._main_split.GetSashPosition())
+            if clamped != self._main_split.GetSashPosition():
+                self._main_split.SetSashPosition(clamped)
+
+        wx.CallAfter(_reclamp)
+
+    def _apply_sash_ratios(self):
+        """Set both splitter sashes from persisted ratios (or defaults).
+
+        Ratios rather than pixels so the layout scales with the window; runs
+        via wx.CallAfter once the frame has real geometry. Clamped so a
+        corrupt state file can't produce a collapsed pane.
+        """
+        try:
+            saved = fm.get_ui_sashes()
+        except Exception:
+            saved = {}
+
+        def _ratio(key, default):
+            try:
+                value = float(saved.get(key, default))
+            except (TypeError, ValueError):
+                value = default
+            return min(0.85, max(0.15, value))
+
+        height = max(1, self._main_split.GetClientSize().height)
+        width = max(1, self._bottom_split.GetClientSize().width)
+        self._main_split.SetSashPosition(
+            self._clamp_main_sash(height * _ratio("main", 0.60)))
+        self._bottom_split.SetSashPosition(int(width * _ratio("bottom", 0.50)))
+
+    def _on_sash_changed(self, event):
+        """Persist sash ratios after a user drag (best-effort)."""
+        event.Skip()
+        try:
+            height = max(1, self._main_split.GetClientSize().height)
+            width = max(1, self._bottom_split.GetClientSize().width)
+            fm.set_ui_sashes(
+                self._main_split.GetSashPosition() / height,
+                self._bottom_split.GetSashPosition() / width)
+        except Exception:
+            # Losing a sash preference is not worth surfacing an error.
+            pass
 
     def _set_font_size(self, size):
         self.font_size = size

--- a/tests.py
+++ b/tests.py
@@ -1025,6 +1025,18 @@ class TestFirmwareManifest(unittest.TestCase):
         loaded = fm_mod._load_state()
         self.assertEqual(loaded, data)
 
+    def test_ui_sashes_roundtrip_and_malformed(self):
+        fm_mod = self._use_temp_state()
+        self.assertEqual(fm_mod.get_ui_sashes(), {})
+        fm_mod.set_ui_sashes(0.6180339, 0.5)
+        saved = fm_mod.get_ui_sashes()
+        self.assertEqual(saved, {"main": 0.618, "bottom": 0.5})
+        # Malformed persisted value degrades to {} instead of raising.
+        state = fm_mod._load_state()
+        state["ui_sashes"] = "garbage"
+        fm_mod._save_state(state)
+        self.assertEqual(fm_mod.get_ui_sashes(), {})
+
     def test_record_flash_creates_entry(self):
         fm_mod = self._use_temp_state()
         fm_mod.record_flash("bf-f8hp-pro", "0.53", "abc123")


### PR DESCRIPTION
## Summary

Requested during hardware testing: the fixed 2:1 layout chronically crushed the Instructions area with no user recourse. The window body is now two `wx.SplitterWindow`s — a horizontal sash between the workflow columns and the bottom row, and a vertical one between Instructions and Log — so space goes wherever the user drags it.

- **Persisted**: sash ratios (relative, so they scale with the window) save to the state file on drag and restore on launch, clamped against corrupt values.
- **Asymmetric minimums**: the columns clamp at 300px (below that the variant walkthrough's fixed-height controls start overlapping — caught by the screenshot sweep and fixed by clamping rather than letting it happen); the bottom row compresses to 140px since both sides are scrollable text. Enforced on drags *and* re-clamped after gravity-driven window resizes.
- The main sash replaces the decorative divider; gravity 0.6 keeps the BalenaEtcher feel on resize.

## Verification

- Screenshot sweep (self-capturing `wx.WindowDC`, 15 states): default ratios, dragged-for-instructions, 1680×940, and 960×540 — no overlap, no crushed panes, walkthrough intact in all.
- Suite 227 → **228** (sash persistence roundtrip + malformed-state degradation), all green.

#38 gets one more rebase onto this after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD