### PR TITLE
Release v26.07.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v26.07.1 — 2026-07-17
 
 ### UX / UI
 

--- a/flash_firmware_gui.py
+++ b/flash_firmware_gui.py
@@ -16,7 +16,7 @@ from gui_main import main, FlasherFrame  # noqa: F401
 # Canonical version — kept here so tests and build tooling can find it
 # by reading this file.  gui_main.py and gui_dialogs.py import their own
 # copy; keep them in sync when bumping.
-VERSION = "26.07.0"
+VERSION = "26.07.1"
 
 # Themes: "mocha" (dark) and "latte" (light) — defined in gui_themes.py.
 # The status-bar ☀ / ☾ button toggles between them; initial choice follows

--- a/gui_main.py
+++ b/gui_main.py
@@ -39,7 +39,7 @@ from gui_download import DownloadController
 from gui_flash import FlashController
 from gui_handset import HandsetController
 
-VERSION = "26.07.0"
+VERSION = "26.07.1"
 
 FONT_SIZES = [9, 11, 12, 14, 16]
 


### PR DESCRIPTION
Version bump + changelog date for v26.07.1. Ships everything since v26.07.0:

- Guided hardware-variant identification (walkthrough in the Firmware column, hardware-verified) + downloader variant safety
- All firmware downloads SHA-256 pinned; UV-25 version corrected to the actual V0.23
- gui_main fully decomposed (2,305 → ~1,188 lines) with the flash controller hardware-verified end-to-end and a real single-flash crash caught+fixed by its new mock coverage
- One-click test reports with nag suppression
- Community translation review process (7 tracking issues, in-app unreviewed hints, stale-cache overlay fix)
- 3-OS CI matrix, actionlint, weekly firmware-drift monitor
- Resizable window: persisted splitters, emulated maximize, manual edge-resize, Log ≤ Instructions

240 tests green on all three OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GmCYGXsTYYkC3BUS2pUAD